### PR TITLE
Display metadata score to curators in a small visualization

### DIFF
--- a/app/assets/javascripts/revs.js
+++ b/app/assets/javascripts/revs.js
@@ -142,6 +142,10 @@ $(document).ready(function(){
       $('#bulk-update-button').addClass('extra-padding');
     }
 
+		// Use item metadata score value to update score visualization
+		var score = $('.item-score').data('score-value');
+		$('.item-score').css('width', score);
+
    // Called when an individual checkbox is checked or unchecked in bulk edit view.
    // Update row status message if user changes individual checkbox
    $('.result-item-checkbox > input[type="checkbox"]').change(function() {

--- a/app/assets/javascripts/revs.js
+++ b/app/assets/javascripts/revs.js
@@ -144,13 +144,17 @@ $(document).ready(function(){
 
 		// Use item metadata score value to update score visualization
 		var score = $('.item-score').data('score-value');
-		$('.item-score').css('width', score);
+		$('.score-viz .item-score').css('width', score);
+		$('.score-viz-detailed .item-score').css('width', score * 2);
+		if (score > 53) {
+			$('.score-viz-detailed .score').addClass('half-full');
+		}
 
    // Called when an individual checkbox is checked or unchecked in bulk edit view.
    // Update row status message if user changes individual checkbox
    $('.result-item-checkbox > input[type="checkbox"]').change(function() {
      var field = $('#bulk_edit_attribute option:selected').text(); // current value of select menu
-     var row = $(this).closest('.result-item')
+     var row = $(this).closest('.result-item');
      toggle_highlight(this,row);
      updateEditStatus(field,"div[data-item-id='" + row.data('item-id') + "']"); // update status message
    });

--- a/app/assets/stylesheets/_catalog.scss
+++ b/app/assets/stylesheets/_catalog.scss
@@ -472,6 +472,32 @@
   span {font-weight: 700;}
 }
 
+// Item metadata score
+.score-viz {
+  margin-bottom: 20px;
+  position: relative;
+
+  .max-score,
+  .item-score {
+    height: 6px;
+    left: 0;
+    position: absolute;
+    top: 0;
+  }
+
+  .max-score {
+    background-color: $revs-gray;
+    width: 100px;
+  }
+
+  .item-score {
+    background-color: $revs-red;
+    opacity: .5;
+    width: 0; // updated to actual item score via JavaScript
+    z-index: 5;
+  }
+}
+
 /* Responsive styles */
 @media screen and (max-width: 991px) {
   .blacklight-catalog-show {

--- a/app/assets/stylesheets/_catalog.scss
+++ b/app/assets/stylesheets/_catalog.scss
@@ -3,36 +3,46 @@
     padding-top: 5px;
     &.section-heading {border-top: 3px solid $revs-gray;}
   }
+
   .documentHeader {
-	  .index_title {
-		  float: left;
-	  }
-	  .documentFunctions {
-		  float: right;
-	  }
+    .index_title {
+      float: left;
+    }
+
+    .documentFunctions {
+      float: right;
+    }
   }
 }
 
 .index_title {color: $revs-gray-light;}
+
 .bookmark_toggle {
-	label {
-		cursor: pointer;
-		display: inline;
-	}
+  label {
+    cursor: pointer;
+    display: inline;
+  }
 }
 
 .blacklight-catalog-show {
   h2 {
     @include page-header;
   }
+
   ul.nav {
     color: $revs-gray-light;
-    font-size: 0.95em;
+    font-size: .95em;
     padding-left: 1px;
-    > li >, > li > div {
-      div, a, a:visited, input.btn-link {
+
+    > li >,
+    > li > div {
+      div,
+      a,
+      a:visited,
+      input.btn-link {
         color: $gray-dark;
         text-decoration: none;
+
         i {
           background-image: none;
           margin-right: 9px;
@@ -48,6 +58,7 @@
   .item-nav {
     float: right;
   }
+
   .nav-header {
     border-bottom: 1px solid #e5e5e5;
     font-size: 11px;
@@ -56,61 +67,78 @@
     margin-bottom: 6px;
     padding: 6px 0 0;
     text-transform: uppercase;
+
     a {
       color: $revs-gray-light;
       text-decoration: none;
     }
+
     i {
       font-weight: 200;
     }
   }
+
   .member-image img {margin-bottom: 20px;}
+
   .show-document-title {
     margin-top: 0;
     padding-top: 0;
   }
+
   .zoom-image-link {
     display: block;
+
     &.visible-phone {margin-bottom: 15px;}
+
     &.hidden-phone {margin-top: 20px; margin-bottom: none;}
   }
+
   .dl-horizontal {
+    font-size: .95em;
     margin-bottom: 0;
-    font-size: 0.95em;
+
     dt {
-      float: left;
       clear: left;
+      float: left;
       text-align: left;
       white-space: normal;
       width: 91px;
+
       label {
         font-weight: normal;
+
         &:after {
-          content: ":";
+          content: ':';
         }
       }
     }
+
     dd {
       margin-left: 100px;
       margin-right: 15px;
+
       p {
         margin-bottom: 0;
         margin-top: 0;
+
         + p {
           margin-top: 12px;
         }
       }
     }
   }
+
   .accordion-group .dl-horizontal .form-group {
     @extend .clearfix; // so values for multiline labels line up vertically
     margin-bottom: 2px;
   }
+
   // in curator edit mode
   form.edit-metadata .accordion-group .dl-horizontal {
     .form-group {
       margin-bottom: 12px;
     }
+
     button {
       float: right;
       margin: 12px 15px;
@@ -118,21 +146,26 @@
 
     // Change when in edit mode so labels are above inputs, both left-aligned
     dt {
-      width: initial;
       margin-right: 20px;
+      width: initial;
+
       label {
         font-weight: bold;
+
         &:after {
-          content: "";
+          content: '';
         }
       }
     }
+
     dd {
       margin-left: initial;
       margin-right: 6px;
+
       .form-control {
         padding: 6px;
       }
+
       .help-block {
         margin-bottom: 0;
         margin-left: 5px;
@@ -144,10 +177,12 @@
     dt {
       width: 75px;
     }
+
     dd {
       margin-left: 10px;
     }
   }
+
   #feedback_link {
     background-color: $white;
     border: 1px solid $gray-ccc;
@@ -157,47 +192,59 @@
     margin-top: 20px;
     padding: 4px 9px;
   }
+
   .results-nav {
     border-bottom: 1px solid $gray-ccc;
-    margin: 0 0 12px 0;
     font-size: 12px;
+    margin: 0 0 12px;
+
     div {
       padding: 0;
     }
+
     .previousNextDocument {
       float: right;
       padding-bottom: 2px;
     }
   }
+
   .accordion {
     margin-bottom: 24px;
     margin-left: 1px;
+
     .accordion-group {
-      border: none;
+      border: 0;
       margin-bottom: 3px;
     }
+
     // removed .nav-header styles from here
     .accordion-toggle {
       padding: 0;
+
       .accordion-icon {
         float: right;
       }
     }
+
     .accordion-inner {
       @extend .clearfix;
       background: #f8f8f8;
-      border-top: none;
+      border-top: 0;
       box-shadow: inset 0 0 10px $gray-lighter, inset 0 0 10px $gray-lighter, inset 0 0 10px $gray-lighter;
       padding: 12px 9px 3px 15px;
+
       dt {
         color: $gray-light;
       }
+
       input[type=submit] {
         float: right;
       }
+
       .mvf {
         margin-bottom: 0;
       }
+
       .item-edit-errors {
         clear: both;
         margin-bottom: 6px;
@@ -207,91 +254,120 @@
   .item-actions {
     li:hover {
       background: $gray-lighter;
+
       &.nav-header {background: inherit;}
     }
+
     li {
       line-height: 20px;
     }
+
     #favorites_link {
       i.fa-heart {
         color: $revs-red;
       }
+
       .button_to {
         display: inline-block;
         margin-bottom: 0;
         vertical-align: top;
+
         input[type=submit] {
           font-size: 13px;
           padding: 0;
         }
       }
     }
+
     .help {
       float: right;
       z-index: 999;
+
       i {
         color: $revs-gray-light;
         font-size: 16px;
       }
     }
+
     #flags_link {
-      padding: 2px 0 2px 0;
+      padding: 2px 0;
     }
+
     &.nav > li > a {
       padding: 2px 15px;
-      &.help, &.purl, &.accordion-toggle {
+
+      &.help,
+      &.purl,
+      &.accordion-toggle {
         padding-left: 0;
         padding-right: 0;
       }
     }
+
     a:hover i, div:hover i {
       color: $revs-red;
     }
+
     #annotate_link {padding: 0;}
+
     a#hide_annotations_link {
       background-color: $gray-lighter;
       padding-left: 0;
+
       i {
         color: $active-link-color;
       }
     }
-    #favorites_link, #user_galleries,
-    #view_annotations_link, #annotate_link, .purl {
+
+    #favorites_link,
+    #user_galleries,
+    #view_annotations_link,
+    #annotate_link,
+    .purl {
       padding: 2px 0;
     }
+
     .flag-history-list li {
-      padding: 6px 0;
       color: $gray;
+      padding: 6px 0;
     }
+
     #user_galleries a i {
      margin-left: 1px;
      margin-right: 15px;
     }
+
     #add_to_gallery_form {
       margin-bottom: 10px;
+
       form {
         margin-bottom: 6px;
         margin-top: 6px;
         padding-bottom: 6px;
       }
     }
+
     select#saved_item_gallery_id {
-      vertical-align: inherit;
       font-size: 13px;
       margin-left: 23px;
       max-width: 300px;
+      vertical-align: inherit;
     }
+
     #current_in_galleries {
       margin-left: 24px;
       padding-bottom: 6px;
+
       ul {
         margin-top: 6px;
         padding-left: 16px;
       }
+
       a {
         color: $active-link-color;
       }
     }
+
     .nav-header {
       i {
         background-image: none;
@@ -300,32 +376,40 @@
         margin-right: 0
       }
     }
+
     &.curator-actions {
       margin-top: 24px;
+
       .curator-action-link {
         display: inline-block;
         padding-left: 0;
+
         &.disabled {
           background-color: $body-bg-color;
+
           i {
             margin-right: 9px;
           }
         }
       }
+
       #item-public-visibility-status a {
         display: inline-block;
       }
+
       #item-edit-history-accordion {
         + #item-edit-history .edit-history-list  {
-          margin: 6px 0 12px 25px;
           background: #f8f8f8;
-          border-top: none;
+          border-top: 0;
           box-shadow: inset 0 0 10px $gray-lighter, inset 0 0 10px $gray-lighter, inset 0 0 10px $gray-lighter;
           color: $gray;
+          margin: 6px 0 12px 25px;
           padding: 12px 9px 3px 15px;
+
           p {
             margin-top: 0;
           }
+
           ul {
             margin-bottom: 6px;
             padding-left: 15px;
@@ -333,24 +417,29 @@
         }
       }
     }
+
     #all_flags, #all-annotations {
       color: $gray;
-      .flag-info, .annotation-info {
-        background: rgba(0,0,0,0.05);
-        border: 1px solid rgba(0,0,0,0.05);
+
+      .flag-info,
+      .annotation-info {
+        background: rgba(0, 0, 0, .05);
+        border: 1px solid rgba(0, 0, 0, .05);
         border-radius: 4px;
-        box-shadow: rgba(0,0,0,0.2) 0 -1px 0,rgba(255,255,255,0.8) 0 1px 0;
+        box-shadow: rgba(0, 0, 0, .2) 0 -1px 0, rgba(255, 255, 255, .8) 0 1px 0;
         color: $gray-light;
-        font-size: 0.9em;
+        font-size: .9em;
         margin: 12px 0;
         padding: 6px 9px;
+
         &:hover {
-          background: rgba(0,0,0,0.1);
-          border: 1px solid rgba(0,0,0,0.1);
-          box-shadow: rgba(0,0,0,0.4) 0 -1px 0,rgba(255,255,255,0.8) 0 1px 0;
+          background: rgba(0, 0, 0, .1);
+          border: 1px solid rgba(0, 0, 0, .1);
+          box-shadow: rgba(0, 0, 0, .4) 0 -1px 0, rgba(255, 255, 255, .8) 0 1px 0;
         }
+
         blockquote {
-          border-left: none;
+          border-left: 0;
           color: $gray;
           font-size: 1em;
           font-style: italic;
@@ -358,6 +447,7 @@
           margin-top: 9px;
           padding-left: 0;
         }
+
         form.button_to {
           margin-bottom: 6px;
           margin-top: 12px;
@@ -365,74 +455,96 @@
         }
       }
     }
+
     .edit-mode-status.label,
     .posterframe-status.label,
     .public-visibility-status.label {
       margin-left: 10px;
     }
+
     .badge {
       background-color: $white;
-      font-size: 0.85em;
+      border: 1px solid $revs-gray-light;
+      color: $revs-red;
+      font-size: .85em;
       font-weight: bold;
       line-height: 1.2;
       margin-left: 5px;
-      color: $revs-red;
-      border: 1px solid $revs-gray-light;
-      padding: 2px 5px 0px;
+      padding: 2px 5px 0;
       vertical-align: text-bottom;
     }
-    form.new_flag, div#all_flags, div#all-annotations {
+
+    form.new_flag,
+    div#all_flags,
+    div#all-annotations {
       margin: 6px 10px 0 25px;
+
       label {
         margin-left: 2px;
       }
+
       .flag-button {
         display: block;
       }
     }
+
     form.new_flag {
       margin-bottom: 24px;
     }
-    form.edit_flag, div#all_flags .flag-info .resolution-history {
+
+    form.edit_flag,
+    div#all_flags .flag-info .resolution-history {
       border-top: 1px dotted $revs-gray-light;
       margin-bottom: 4px;
       margin-top: 12px;
       padding-top: 6px;
+
       label {
         display: inline;
         font-weight: 700;
         margin-left: 0;
       }
+
       span {
         display: block;
       }
     }
+
     #flag_resolution {
       width: 90%;
     }
+
     #new_flag_form {
       label {
         font-weight: normal;
       }
+
       input#flag_notify_me {
         margin-bottom: 12px;
         vertical-align: baseline;
       }
     }
-    div#all-annotations, div#all_flags .flag-info {
+
+    div#all-annotations,
+    div#all_flags .flag-info {
       margin-top: 0;
+
       .flag-button {
         display: inline-block;
       }
     }
+
     #all_flags {
       padding-bottom: 1px;
     }
+
     a.flag-details {
       margin-bottom: 6px;
+
       &.active {
         background-color: $gray-lighter;
       }
+
       &:hover {
         i {
           color: $revs-red;
@@ -440,26 +552,32 @@
       }
     }
   }
+
   .license-image {
-    font-size: 0.9em;
+    font-size: .9em;
     margin-top: 24px;
   }
+
   .pe-img-viewer-thumbs-nav-bottom {
     img.pe-img-canvas {
       border: 1px solid $gray-ccc;
       cursor: pointer;
     }
+
     .pe-purl-url {
       border-top-style: none;
       margin-left: 3px;
     }
+
     .pe-display-note {
       font-size: 13px;
       line-height: 1.4;
     }
+
     .pe-full-screen-ctrl {
       width: 24px;
     }
+
     .zpr-controls img {
       width: initial;
     }
@@ -467,19 +585,56 @@
 }
 
 .revs-identifier {
-  font-size: 0.8em;
+  font-size: .8em;
   margin-left: 3px;
+
   span {font-weight: 700;}
 }
 
 // Item metadata score
 .score-viz {
+  height: 6px;
+  width: 100px;
+}
+
+.score-viz-detailed {
+  $score-viz-detailed-width: 200px;
+  height: 17px;
+  margin-top: 6px;
+  width: $score-viz-detailed-width;
+
+  .score {
+    color: $gray-base;
+    font-size: 13px;
+    left: ($score-viz-detailed-width / 2) - 7;
+    position: absolute;
+    text-shadow: 0 1px 0 $white;
+    z-index: 10;
+
+    &.half-full {
+      color: $white;
+      text-shadow: 0 1px 0 $gray-base;
+    }
+  }
+
+  .max-score {
+    border-bottom-right-radius: 3px;
+    border-top-right-radius: 3px;
+  }
+
+  .item-score {
+    border-bottom-left-radius: 3px;
+    border-top-left-radius: 3px;
+  }
+}
+
+.score-viz,
+.score-viz-detailed {
   margin-bottom: 20px;
   position: relative;
 
   .max-score,
   .item-score {
-    height: 6px;
     left: 0;
     position: absolute;
     top: 0;
@@ -487,18 +642,45 @@
 
   .max-score {
     background-color: $revs-gray;
-    width: 100px;
+    height: 100%;
+    width: 100%;
   }
 
   .item-score {
     background-color: $revs-red;
+    height: 100%;
     opacity: .5;
     width: 0; // updated to actual item score via JavaScript
     z-index: 5;
   }
 }
 
-/* Responsive styles */
+.edit-metadata .score-viz-detailed {
+  margin-top: 25px;
+}
+
+// Responsive styles
+
+@media screen and (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+  .score-viz-detailed { // has to be narrower on sm viewport
+    $score-viz-detailed-width: 120px;
+    width: $score-viz-detailed-width;
+
+    .score {
+      left: ($score-viz-detailed-width / 2) - 7;
+
+      &.half-full {
+        color: $gray-base;
+        text-shadow: 0 1px 0 $white;
+      }
+    }
+
+    .item-score {
+      background-color: transparent; // hide colored part of viz on sm viewports
+    }
+  }
+}
+
 @media screen and (max-width: 991px) {
   .blacklight-catalog-show {
     .metadata {
@@ -506,9 +688,11 @@
       margin-top: 20px;
     }
   }
+
   .unresolved-label {
     display: none;
   }
+
   .blacklight-catalog-show #sidebar-nav {
     border-top: 5px solid $revs-gray;
     margin-top: 20px;
@@ -518,24 +702,20 @@
 @media screen and (max-width: 991px) and (min-width: 768px) {
   .blacklight-catalog-show .metadata {
     margin-top: 5px;
-    .dl-horizontal {
-      dt {
-        float: left;
-        clear: none;
-      }
+
+    .dl-horizontal dt {
+      clear: none;
+      float: left;
     }
+
     #new_saved_item input[type="submit"] {
       float: right;
       margin-right: 12px;
     }
+
     #current_in_galleries {
       clear: right;
       padding-top: 12px;
-    }
-    form {
-      dt {
-
-      }
     }
   }
 }
@@ -546,21 +726,27 @@
       margin-top: 10px;
       text-align: center;
     }
+
     .back-to-results {
       display: inline;
     }
+
     dt {
       float: none;
     }
+
     dd {
       margin-left: 0;
     }
+
     .results-nav {
       clear: left;
       padding-top: 30px;
     }
+
     .results-pagination {
       display: inline;
+
       .previousNextDocument {
         float: none;
         margin-left: 30px;

--- a/app/views/catalog/_show_collection_member.html.erb
+++ b/app/views/catalog/_show_collection_member.html.erb
@@ -42,7 +42,12 @@
     <noscript>
         <%= link_to(image_tag(@document.images(:large).first), "#{Revs::Application.config.purl}/#{@document[:id]}",:target=>'_new') %>
     </noscript>
-    <div class="revs-identifier"><span><%=t('revs.show.label_identifier') %>:</span> <%=@document.identifier%></div>
+
+    <div class="revs-identifier">
+      <span><%= t('revs.show.label_identifier') %>:</span>
+      <%= @document.identifier %>
+    </div>
+
   </div>
 
   <div class="col-sm-5 metadata">
@@ -50,13 +55,13 @@
     <% if from_gallery? %>
       <div class="row results-nav">
         <div class="col-sm-6 back-to-results">
-          <%= link_to t('revs.nav.return_to_gallery').html_safe, gallery_path(params[:gallery_id],extract_paging_params(params)) %>
+          <%= link_to t('revs.nav.return_to_gallery').html_safe, gallery_path(params[:gallery_id], extract_paging_params(params)) %>
         </div>
       </div>
     <% elsif from_favorites? %>
       <div class="row results-nav">
         <div class="col-sm-6 back-to-results">
-           <%=link_to t('revs.nav.return_to_favorites',:user_name=>params[:favorite_user_name]).html_safe,user_favorites_user_index_path(params[:user],extract_paging_params(params)) %>
+           <%=link_to t('revs.nav.return_to_favorites', :user_name=>params[:favorite_user_name]).html_safe, user_favorites_user_index_path(params[:user], extract_paging_params(params)) %>
         </div>
       </div>
     <% elsif in_search_result?  %>
@@ -78,16 +83,24 @@
 
     <div class="row">
       <div class="col-sm-12">
-        <h4 class="show-document-title"><%=@document.title%></h4>
+        <h4 class="show-document-title"><%= @document.title %></h4>
+
+        <%# Show curators a small metadata score visualization %>
+        <% if can? :curate, :all %>
+          <div class="score-viz">
+            <div class="max-score"></div>
+            <div class="item-score" data-score-value="<%= @document.score %>"></div>
+          </div>
+        <% end %>
 
         <div id="item_details">
-          <%= render :partial => "show_default_collection_member", :locals => {:document => @document} %>
+          <%= render :partial => "show_default_collection_member", :locals => { :document => @document } %>
         </div>
 
         <ul class="nav list-unstyled item-actions">
-          <li class="nav-header"><%=t('revs.admin.sidebar.actions')%></li>
+          <li class="nav-header"><%= t('revs.admin.sidebar.actions') %></li>
 
-          <% if can?(:create, SavedItem) && (@document.visibility != :hidden || @document.is_favorite?(current_user))%>
+          <% if can?(:create, SavedItem) && (@document.visibility != :hidden || @document.is_favorite?(current_user)) %>
             <li>
               <div id="favorites_link">
                 <%= render :partial=>'saved_items/add_to_favorites'%>
@@ -95,7 +108,7 @@
             </li>
           <% end %>
 
-          <% if can?(:create, Gallery) && can?(:create, SavedItem) && @document.visibility != :hidden%>
+          <% if can?(:create, Gallery) && can?(:create, SavedItem) && @document.visibility != :hidden %>
             <li>
               <div id="user_galleries">
                 <%= render(:partial => "saved_items/add_to_gallery") %>
@@ -104,7 +117,7 @@
           <% end %>
 
           <% if (can?(:read, Annotation) || can?(:create, Annotation))
-               @annotations = @document.annotations(current_user)
+              @annotations = @document.annotations(current_user)
               annotation_link_text = can?(:create, Annotation) ?  t('revs.annotations.add') : t('revs.annotations.view')
               annotation_link_id = can?(:create, Annotation) ?  "annotate_link" : "view_annotations_link"
               annotation_link_class = can?(:create, Annotation) || @annotations.size > 0 ? "" : "hidden"
@@ -129,13 +142,13 @@
             "#{Revs::Application.config.purl}/#{@document[:id]}",:target=>"_new", :class => "purl") %>
           </li>
 
-          <% if (can?(:read, Flag) || can?(:add_new_flag_to, @document))  %>
+          <% if (can?(:read, Flag) || can?(:add_new_flag_to, @document)) %>
               <li>
 
                 <div id="flags_link">
-                  <%= render :partial=>'flags/link'%>
+                  <%= render :partial=>'flags/link' %>
                   <%# only show help icon if user can add flags %>
-                  <% if can? :add_new_flag_to, @document  %>
+                  <% if can? :add_new_flag_to, @document %>
                     <%= link_to "#", :class => "help hidden-offscreen showOnLoad", :data => { :toggle => "tooltip", :placement => "left", :title => "#{t('revs.flags.help')}" } do %>
                       <i class="fa fa-question-sign"></i>
                     <% end %>
@@ -143,30 +156,30 @@
                 </div>
 
                 <div id="new_flag_form">
-                  <%= render :partial=>"flags/new",:locals=>{:druid=>@document.id, :flags=>@document.flags} %>
+                  <%= render :partial=>"flags/new", :locals => { :druid=>@document.id, :flags=>@document.flags } %>
                 </div>
 
                 <div id="all_flags">
-                  <%= render :partial=>"flags/all",:locals=>{:flags=>@document.flags} %>
+                  <%= render :partial=>"flags/all", :locals => { :flags=>@document.flags } %>
                 </div>
 
             </li>
 
             <% if can?(:add_new_flag_to, @document) && current_user  # flagging history area
-              closed_flags=@document.flags.where(:state=>Flag.closed) # get all closed flags
+              closed_flags = @document.flags.where(:state=>Flag.closed) # get all closed flags
               if cannot?(:curate,:all) # non curators can only see their OWN closed flags
-                closed_flags=closed_flags.where(:user_id=>current_user.id)
-                label_text=t('revs.flags.your_closed_flags')
+                closed_flags = closed_flags.where(:user_id=>current_user.id)
+                label_text = t('revs.flags.your_closed_flags')
               else
-                label_text=t('revs.flags.all_closed_flags')
+                label_text = t('revs.flags.all_closed_flags')
               end
-              if closed_flags.size > 0  # show the flagging history to logged in users%>
+              if closed_flags.size > 0  # show the flagging history to logged in users %>
                 <li id="item-flag-history-accordion">
                   <a class="accordion-toggle" data-toggle="collapse" data-parent="#item-flag-history-accordion" href="#item-flag-history">
                     <i class="fa fa-list-ol"></i>
-                    <%=label_text%>
-                    <span class="<%=display_class(closed_flags.size)%> badge badge-revs num-closed-flags-badge">
-                     <%= closed_flags.size%>
+                    <%= label_text%>
+                    <span class="<%= display_class(closed_flags.size) %> badge badge-revs num-closed-flags-badge">
+                     <%= closed_flags.size %>
                    </span>
                   </a>
                 </li>
@@ -174,20 +187,20 @@
                   <div class="flag-history-list">
                     <ul>
                       <% closed_flags.each do |flag| %>
-                        <li><%=t('revs.flags.flag_history',:flagger=>(flag.user == current_user ? t('revs.user.you') : (flag.user.blank? ? t('revs.user.anonymous') : flag.user.to_s)),:comment=>flag.comment,:flag_date=>show_as_datetime(flag.created_at.in_time_zone),:state_name=>flag.state_display_name,:resolver=>(flag.resolving_user == current_user.id ? t('revs.user.you') : flag.resolved_by.to_s),:resolve_date=>show_as_datetime(flag.resolved_time.in_time_zone))%>
-                          <%=t('revs.flags.flag_history_comment',:comment=>flag.resolution) unless flag.resolution.blank? %>
+                        <li><%= t('revs.flags.flag_history', :flagger=>(flag.user == current_user ? t('revs.user.you') : (flag.user.blank? ? t('revs.user.anonymous') : flag.user.to_s)), :comment=>flag.comment, :flag_date=>show_as_datetime(flag.created_at.in_time_zone), :state_name=>flag.state_display_name, :resolver=>(flag.resolving_user == current_user.id ? t('revs.user.you') : flag.resolved_by.to_s), :resolve_date=>show_as_datetime(flag.resolved_time.in_time_zone)) %>
+                          <%= t('revs.flags.flag_history_comment', :comment=>flag.resolution) unless flag.resolution.blank? %>
                         </li>
                       <% end %>
                     </ul>
                   </div>
                 </div>
-                <% end # end check for a logged in user having resolved flags%>
+                <% end # end check for a logged in user having resolved flags %>
             <% end # end check for user has ability to add flags%>
 
-              <% if !user_signed_in? && can?(:add_new_flag_to, @document)%>
+              <% if !user_signed_in? && can?(:add_new_flag_to, @document) %>
               <li>
                 <span id="feedback_link">
-                  <%= t('revs.nav.content_corrections',:create_an_account_link=>link_to(t('revs.nav.create_an_account'),new_user_session_path),:feedback_link=>link_to(t('revs.nav.feedback'),contact_us_path(:from=>request.path,:subject=>'metadata',:message=>"Correction to \"#{@document.title}\" (identifier: #{@document.identifier})"))).html_safe %>
+                  <%= t('revs.nav.content_corrections', :create_an_account_link => link_to(t('revs.nav.create_an_account'), new_user_session_path), :feedback_link => link_to(t('revs.nav.feedback'), contact_us_path(:from => request.path, :subject => 'metadata', :message => "Correction to \"#{@document.title}\" (identifier: #{@document.identifier})"))).html_safe %>
                 </span>
               </li>
               <% end %>
@@ -197,7 +210,7 @@
 
         <% if can? :curate, :all %>
           <ul class="nav list-unstyled item-actions curator-actions showOnLoad hidden-offscreen">
-            <li class="nav-header"><%=t('revs.curator.curator_actions')%></li>
+            <li class="nav-header"><%= t('revs.curator.curator_actions') %></li>
             <% if can? :update_metadata, :all
                 edit_mode_link_text = in_curator_edit_mode ? t('revs.curator.leave_edit_mode') : t('revs.curator.enter_edit_mode')
                 %>
@@ -216,7 +229,7 @@
               </li>
               <div id="item-edit-history" class="collapse">
                 <div class="edit-history-list">
-                  <p><%=t('revs.curator.metadata_edit_history_description')%>:</p>
+                  <p><%= t('revs.curator.metadata_edit_history_description') %>:</p>
                   <ul>
                     <% @document.edits.each do |edit| %>
                       <li><%=show_as_datetime(edit.created_at.in_time_zone)%> by <%=edit.user.to_s%></li>

--- a/app/views/catalog/_show_default_collection_member.html.erb
+++ b/app/views/catalog/_show_default_collection_member.html.erb
@@ -151,7 +151,15 @@
 
             <%= render :partial=>'/catalog/metadata_field',:locals=>{:document=>document,:field_name=>'has_more_metadata',:label=>t('revs.show.label_more_metadata'),:simple_format=>true,:editable=>true} %>
 
-            <%= render :partial=>'/catalog/metadata_field',:locals=>{:document=>document,:field_name=>'score',:label=>t('revs.show.label_score'),:editable=>false} %>
+            <%# Show metadata score in a visualization %>
+            <dt><%= label_tag "score-viz-detailed", t('revs.show.label_score'), class: "control-label" %></dt>
+            <dd>
+              <div class="score-viz-detailed">
+                <div class="max-score"></div>
+                <div class="item-score" data-score-value="<%= @document.score %>"></div>
+                <div class="score"><%= @document.score %></div>
+              </div>
+            </dd>
 
           <% end %>
 


### PR DESCRIPTION
Closes #4 

For curators only, shows a small visualization under the item title to give them a rough idea of how complete the metadata is for that item:

![small](https://cloud.githubusercontent.com/assets/101482/7663908/64861fbe-fb28-11e4-90ab-9e21ca2d0306.png)
--

When a curator expands the Sources, Notes metadata section, the same visualization is shown, but larger and with the actual item score shown:

![revs_digital_library__thompson_raceway__may_1](https://cloud.githubusercontent.com/assets/101482/7663917/8a006efc-fb28-11e4-826b-abe3365539e0.png)
