### PR TITLE
Add archive label to various pages

### DIFF
--- a/app/assets/javascripts/revs-carousel.js
+++ b/app/assets/javascripts/revs-carousel.js
@@ -37,6 +37,7 @@ $(document).ready(function(){
   // When new item slides into view, update metadata shown for item
   $('.homepage-carousel').on('jcarousel:targetin', 'li', function() {
     $("#featured-collection-nav #collection-title-link").text($(this).attr("data-collection-title"));
+    $("#featured-collection-nav #collection-archive").text($(this).attr("data-collection-archive"));
     $("#featured-collection-nav #collection-title-link").attr('href', $(this).attr("data-collection-href"));
     $("#featured-collection-nav #collection-image-link").attr('href', $(this).attr("data-collection-href"));
     $("#featured-collection-nav #collection-description").text($(this).attr("data-collection-description"));
@@ -48,7 +49,7 @@ $(document).ready(function(){
   $('.collection_carousel').on('jcarousel:targetin', 'li', function() {
     var current_item = $(this);
     current_item.addClass('active');
-    var druid= $('.collection_carousel').attr('data-druid');
+    var druid = $('.collection_carousel').attr('data-druid');
     var index = parseInt(current_item.attr('data-image-number'));
     var rows = parseInt($('.collection_carousel').attr('rows'));
     var start = parseInt($('.collection_carousel').attr('start'));
@@ -59,7 +60,7 @@ $(document).ready(function(){
       $.getScript("/update_carousel?druid=" + druid + "&rows=" + rows + "&start=" + end);
     }
     // Ensure jCarousel knows about remotely added items and makes next button active
-    if ((index % 5) == 0) {
+    if ((index % 5) === 0) {
       $('.collection_carousel').jcarousel('reload');
     }
   });

--- a/app/assets/javascripts/revs-carousel.js
+++ b/app/assets/javascripts/revs-carousel.js
@@ -37,7 +37,7 @@ $(document).ready(function(){
   // When new item slides into view, update metadata shown for item
   $('.homepage-carousel').on('jcarousel:targetin', 'li', function() {
     $("#featured-collection-nav #collection-title-link").text($(this).attr("data-collection-title"));
-    $("#featured-collection-nav #collection-archive").text($(this).attr("data-collection-archive"));
+    $("#featured-collection-nav .archive-label").text($(this).attr("data-collection-archive"));
     $("#featured-collection-nav #collection-title-link").attr('href', $(this).attr("data-collection-href"));
     $("#featured-collection-nav #collection-image-link").attr('href', $(this).attr("data-collection-href"));
     $("#featured-collection-nav #collection-description").text($(this).attr("data-collection-description"));

--- a/app/assets/stylesheets/_catalog.scss
+++ b/app/assets/stylesheets/_catalog.scss
@@ -591,6 +591,13 @@
   span {font-weight: 700;}
 }
 
+#document.blacklight-collection {
+  .archive-label {
+    @include archive-label;
+    margin-left: 0;
+  }
+}
+
 // Item metadata score
 .score-viz {
   height: 6px;

--- a/app/assets/stylesheets/_homepage.scss
+++ b/app/assets/stylesheets/_homepage.scss
@@ -1,5 +1,4 @@
 // Homepage carousel
-
 // Default values are for screen sizes 1200px and larger
 $collection-image-container: 402px;
 $collection-image-right-gutter: 30px;
@@ -42,12 +41,18 @@ $collection-image-right-gutter: 30px;
   }
 
   h3 {
+    margin-bottom: 6px;
     margin-top: 0;
     padding-top: 0;
 
     > a {
-     color: $gray-base;
+      color: $gray-base;
     }
+  }
+
+  .archive-label {
+    @include archive-label;
+    margin-left: 0;
   }
 }
 

--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -37,6 +37,13 @@
   top: 0;
 }
 
+@mixin archive-label {
+  background-color: $white;
+  border: 1px dotted $revs-red;
+  color: $revs-red;
+  padding: 2px 6px 1px;
+}
+
 @mixin result-controls {
   font-size: 12px;
 

--- a/app/assets/stylesheets/_search_results.scss
+++ b/app/assets/stylesheets/_search_results.scss
@@ -439,7 +439,8 @@
 }
 
 #sort-dropdown,
-#per_page-dropdown {
+#per_page-dropdown,
+#archive-filter {
   margin-top: 3px;
   z-index: 9999;
 
@@ -464,6 +465,14 @@
 
   > a {padding: 2px;}
 
+}
+
+#archive-filter {
+  float: right;
+
+  .dropdown-toggle .caret {
+    color: $gray-base;
+  }
 }
 
 span.constraints-label {margin-right: .5em;}

--- a/app/assets/stylesheets/_search_results.scss
+++ b/app/assets/stylesheets/_search_results.scss
@@ -18,6 +18,12 @@
     padding-top: 0;
     position: relative;
   }
+
+  .archive-label {
+    @include archive-label;
+    display: inline-block;
+    margin: 4px 0;
+  }
 }
 
 // Gallery View
@@ -66,7 +72,7 @@
 
 // Collections - Grid View
 #documents.gallery .blacklight-collection {
-  min-height: 205px;
+  min-height: 222px;
   min-width: 188px;
   text-align: center;
 
@@ -88,6 +94,7 @@
 
   .collection-details {
     margin-bottom: 20px;
+    margin-top: 12px;
 
     span.label {
       display: inline-block;
@@ -173,6 +180,10 @@
   .collection-title {
     margin-left: 0;
     padding-left: 0;
+  }
+
+  .index_title {
+    margin-bottom: 3px;
   }
 }
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -101,14 +101,14 @@ class CatalogController < ApplicationController
       end
       @saved_items=@gallery.saved_items(current_user).limit(CatalogController.blacklight_config.collection_member_grid_items)
     end
-    
+
     # some logic around the display of reproduction statements which is special for revs items and includes contact links, which is why it is not in the model
     if @document && @document.revs_item? && !@document.reproduction_not_available?
-  
+
       @use_and_reproduction=""
       @use_and_reproduction += I18n.t('revs.contact.image_reuse_agreement',
           :license_agreement_link => ActionController::Base.helpers.link_to(t('revs.contact.image_license_agreement'),
-          'http://revsinstitute.org/research-education/permission-to-use',:target=>'_new')).html_safe 
+          'http://revsinstitute.org/research-education/permission-to-use',:target=>'_new')).html_safe
       @use_and_reproduction += I18n.t('revs.contact.reuse_contact',
           :reuse_contact_link => ActionController::Base.helpers.link_to(t('revs.contact.contact_linktext_html'),
           contact_us_path(:subject=>'terms of use',
@@ -119,8 +119,8 @@ class CatalogController < ApplicationController
           )))).html_safe
 
     elsif @document
-  
-      @use_and_reproduction = @document.use_and_reproduction 
+
+      @use_and_reproduction = @document.use_and_reproduction
 
     end
 
@@ -246,8 +246,8 @@ class CatalogController < ApplicationController
     config.add_facet_field 'marque_ssim', :label => 'Marque', :limit => 25
     config.add_facet_field 'model_year_ssim', :label => 'Model Year', :sort => 'index', :limit => 25
     config.add_facet_field 'model_ssim', :label => 'Model', :limit => 25
-    config.add_facet_field 'collection_ssim', :label => "Collection"
     config.add_facet_field 'archive_ssi', :label => "Archive"
+    config.add_facet_field 'collection_ssim', :label => "Collection"
     config.add_facet_field 'photographer_ssi', :label => "Photographer", :limit => 25
     config.add_facet_field 'entrant_ssim', :label => "Entrant", :limit => 25
     config.add_facet_field 'people_ssim', :label => "People", :limit => 25

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -240,4 +240,9 @@ module ApplicationHelper
     html.html_safe
   end
 
+  # create label with name of archive
+  def archive_label(archive)
+    content_tag(:span, archive, class: ['label', 'label-default', 'archive-label'])
+  end
+
 end

--- a/app/views/about/_archives.html.erb
+++ b/app/views/about/_archives.html.erb
@@ -1,0 +1,10 @@
+<div class="row">
+
+  <div class="col-sm-12">
+    <%= t('revs.about.archives.collier_html') %>
+    <%= t('revs.about.archives.road_and_track_html') %>
+  </div>
+
+</div>
+
+<%= render :partial=>'end_page_slug'%>

--- a/app/views/about/_show_about_sidebar.html.erb
+++ b/app/views/about/_show_about_sidebar.html.erb
@@ -6,6 +6,7 @@
 			<li><%= link_to t('revs.about.project_team'), about_pages_path(:id=>'team') %></li>
 			<li><%= link_to t('revs.about.acknowledgements'), about_pages_path(:id=>'acknowledgements')%></li>
 			<li><%= link_to t('revs.about.contributors_title'), about_pages_path(:id=>'contributors') if Revs::Application.config.featured_contributors && Revs::Application.config.featured_contributors.size > 0 %></li>
+			<!-- <li><%= link_to t('revs.about.archives_title'), about_pages_path(:id=>'archives') %></li> -->
 	  </ul>
 
     <%# List of links to FAQ and other help pages %>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -25,9 +25,7 @@
           <div class="collection-teaser">
             <span class="content-type collection"><%= t('revs.collection.featured_collection')%></span>
             <h3><%= link_to clean_collection_name(@highlight_collections.first.title), collection_path(@highlight_collections.first), :id => "collection-title-link" %></h3>
-            <span id="collection-archive" class="label label-default archive-label">
-              <%= @highlight_collections.first.archive_name %>
-            </span>
+            <%= archive_label(@highlight_collections.first.archive_name) %>
             <p>
               <span id="collection-description"><%= truncate(@highlight_collections.first.description,:length=>310) %></span>
               <%= link_to t('revs.nav.more'), collection_path(@highlight_collections.first), :id => "collection-link" %>
@@ -57,9 +55,7 @@
         <div id="featured-description">
           <span class="content-type collection"><%= t('revs.collection.featured_collection')%></span>
           <h3><%= link_to clean_collection_name(collection.title), collection_path(collection), :id => "collection-title-link" %></h3>
-          <span id="collection-archive" class="label label-default archive-label">
-            <%= collection.archive_name %>
-          </span>
+          <%= archive_label(collection.archive_name) %>
           <p>
             <span id="collection-description"><%= truncate(collection.description,:length=>300) %></span>
             <%= link_to "#{t('revs.nav.more')}", collection_path(collection), :id => "collection-link" %>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -6,7 +6,11 @@
         <div class="homepage-carousel carousel">
           <ul>
             <% @highlight_collections.each_with_index do |collection, index| %>
-              <li class="item<%= " active" if index == 0 %>" data-collection-title="<%= clean_collection_name(collection.title) %>" data-collection-href="<%= collection_path(collection) %>" data-collection-description="<%= truncate(collection.description,:length=>250) %>">
+              <li class="item<%= " active" if index == 0 %>"
+                data-collection-title="<%= clean_collection_name(collection.title) %>"
+                data-collection-href="<%= collection_path(collection) %>"
+                data-collection-archive="<%= collection.archive_name %>"
+                data-collection-description="<%= truncate(collection.description,:length=>250) %>">
                 <a id="collection-image-link" href="<%=collection_path(collection)%>"><%=image_tag collection.first_image(:include_hidden=>can?(:view_hidden, SolrDocument))%></a>
               </li>
             <% end %>
@@ -21,6 +25,9 @@
           <div class="collection-teaser">
             <span class="content-type collection"><%= t('revs.collection.featured_collection')%></span>
             <h3><%= link_to clean_collection_name(@highlight_collections.first.title), collection_path(@highlight_collections.first), :id => "collection-title-link" %></h3>
+            <span id="collection-archive" class="label label-default archive-label">
+              <%= @highlight_collections.first.archive_name %>
+            </span>
             <p>
               <span id="collection-description"><%= truncate(@highlight_collections.first.description,:length=>310) %></span>
               <%= link_to t('revs.nav.more'), collection_path(@highlight_collections.first), :id => "collection-link" %>
@@ -50,6 +57,9 @@
         <div id="featured-description">
           <span class="content-type collection"><%= t('revs.collection.featured_collection')%></span>
           <h3><%= link_to clean_collection_name(collection.title), collection_path(collection), :id => "collection-title-link" %></h3>
+          <span id="collection-archive" class="label label-default archive-label">
+            <%= collection.archive_name %>
+          </span>
           <p>
             <span id="collection-description"><%= truncate(collection.description,:length=>300) %></span>
             <%= link_to "#{t('revs.nav.more')}", collection_path(collection), :id => "collection-link" %>

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -23,6 +23,7 @@ $(document).ready(function(){
 	</div>
 	<div class="col-sm-5 col-lg-6 collection-description">
 		<h4 class="show-document-title"><%= fix_revs_institute_name(document.title.html_safe) %></h4>
+		<%= archive_label(document.archive_name) %>
 		<%= render :partial => "show_default_collection", :locals => {:document => @document} %>
 	</div>
 </div>

--- a/app/views/catalog/_show_default_collection_member.html.erb
+++ b/app/views/catalog/_show_default_collection_member.html.erb
@@ -12,9 +12,9 @@
       <div class="accordion-inner">
         <dl class="dl-horizontal  dl-invert">
 
-          <%= render :partial=>'/catalog/metadata_field',:locals=>{:document=>document,:field_name=>'collection_names',:label=>t('revs.show.label_collection'),:multivalued=>true,:facet=>true,:editable=>false} %>
-
           <%= render :partial=>'/catalog/metadata_field',:locals=>{:document=>document,:field_name=>'archive_name',:label=>t('revs.show.label_archive'),:facet=>true,:editable=>false} %>
+
+          <%= render :partial=>'/catalog/metadata_field',:locals=>{:document=>document,:field_name=>'collection_names',:label=>t('revs.show.label_collection'),:multivalued=>true,:facet=>true,:editable=>false} %>
 
           <%= render :partial=>'/catalog/metadata_field',:locals=>{:document=>document,:field_name=>'title',:label=>t('revs.show.label_title'),:editable=>true} if in_curator_edit_mode %>
 

--- a/app/views/collection/_detailed.html.erb
+++ b/app/views/collection/_detailed.html.erb
@@ -13,6 +13,7 @@
                 t('revs.collection_members.items_name')) %>)
           </span>
         </h5>
+        <%= archive_label(collection.archive_name) %>
       </div>
     </div>
     <div class="row collection-details">

--- a/app/views/collection/_grid.html.erb
+++ b/app/views/collection/_grid.html.erb
@@ -1,6 +1,6 @@
 <div id="documents" class="gallery">
   <ul class="image-grid">
-    <% @collections.each do |collection| 
+    <% @collections.each do |collection|
       collection_title=fix_revs_institute_name(collection.title.html_safe)%>
       <li class="image-item">
         <div class="blacklight-collection document">
@@ -10,6 +10,7 @@
 
           <h5 class="index_title">
             <%= link_to_document collection, collection_title %>
+            <%= archive_label(collection.archive_name) %>
             <span class="text-muted">
               (<%= pluralize(number_with_delimiter(collection.collection_members(:include_hidden=>can?(:view_hidden, SolrDocument)).total_members),
                   t('revs.collection_members.items_name')) %>)

--- a/app/views/collection/index.html.erb
+++ b/app/views/collection/index.html.erb
@@ -7,11 +7,26 @@
   </h2>
 
   <div class="row results-controls">
-    <div class="col-md-4 view-toggle">
+    <div class="col-sm-6 view-toggle">
       <div class='gallery_toggle hidden showOnLoad tabbable'>
         <ul class="nav nav-pills">
           <li><%= link_to(t('revs.nav.grid'), all_collections_path(params.symbolize_keys.merge(:view => nil)), :class=>"#{'active' if @view == 'grid'}") %></li>
           <li><%= link_to(t('revs.nav.detailed'), all_collections_path(params.symbolize_keys.merge(:view => 'detailed')), :class=>"#{'active'if @view == 'detailed'}") %></li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="col-sm-6 hidden-xs">
+      <span class="sr-only"><%= t('revs.nav.filter_archive_sr_only') %></span>
+      <div id="archive-filter" class="btn-group">
+        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+          <%= t('revs.nav.filter_archive') %> <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu">
+          <%# TODO: The menu items and links need to be populated dynamically
+              and call a query that filters out other archives %>
+          <li><a href="#">Collier Collection</a></li>
+          <li><a href="#">Road and Track</a></li>
         </ul>
       </div>
     </div>

--- a/config/locales/about.en.yml
+++ b/config/locales/about.en.yml
@@ -100,4 +100,15 @@ en:
             and helped improve the information on many of the images.
           </p>
         flags: "fixed flags"
-
+      archives_title: 'Content Donors'
+      archives:
+        collier_html: |
+          <h3>Collier Collection</h3>
+          <p>
+            This is text about the Collier Collection.
+          </p>
+        road_and_track_html: |
+          <h3>Road and Track Archive</h3>
+          <p>
+            This is text about the Road and Track Archive.
+          </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,8 @@ en:
       marques: "Marques"
       venues: "Venues"
       tracks: "Tracks"
+      filter_archive: 'Filter by archive'
+      filter_archive_sr_only: 'Filter collections by archive'
     contact:
       us: 'contact us'
       instructions_html: 'If you would like to purchase an image, our policies and Image Order Forms can be found here: %{reuse_link}  Or, if you have questions about placing an order, select "Contact the Image Sales Department." If you have corrections to metadata or content on the site, please use the "Flag correction to this item" link next to the image.'

--- a/spec/features/about_page_spec.rb
+++ b/spec/features/about_page_spec.rb
@@ -9,6 +9,7 @@ describe("About Pages",:type=>:request,:integration=>true) do
     @contact_us=I18n.t("revs.about.contact_title")
     @terms_of_use=I18n.t("revs.about.terms_of_use_title")
     @video_tutorials=I18n.t("revs.about.video_tutorials_title")
+    @archives_title = I18n.t('revs.about.archives_title')
     RevsMailer.stub_chain(:contact_message,:deliver).and_return('a mailer')
   end
 
@@ -82,4 +83,8 @@ describe("About Pages",:type=>:request,:integration=>true) do
     expect(page).to have_link(I18n.t("revs.help.videos.titles.overview"), href: "https://www.youtube.com/watch?v=dkMS7jTseVk")
   end
 
+  it 'should show the content donors page' do
+    visit '/about/archives'
+    expect(page).to have_content(@archives_title)
+  end
 end

--- a/spec/features/item_visibility_spec.rb
+++ b/spec/features/item_visibility_spec.rb
@@ -10,7 +10,7 @@ describe("Item Visibility",:type=>:request,:integration=>true) do
     @nadig_collection_druid='kz071cg8658'
     @nadig_collection_path=catalog_path(@nadig_collection_druid)
   end
-  
+
   it "should update image visibility" do
     item1=Item.where(:druid=>@hidden_druid)
     expect(item1.size).to eq 1
@@ -31,7 +31,7 @@ describe("Item Visibility",:type=>:request,:integration=>true) do
     item1=Item.where(:druid=>@hidden_druid)
     expect(item1.size).to eq 1
     expect(item1.first.visibility).to eq :hidden
-    
+
     doc2=SolrDocument.find(@visible_druid)
     expect(doc2.visibility_value).to eq ""
     expect(doc2.visibility).to eq :visible
@@ -45,9 +45,9 @@ describe("Item Visibility",:type=>:request,:integration=>true) do
     expect(doc3.visibility_value).to eq 1
     expect(doc3.visibility).to eq :visible
 
-    reindex_solr_docs([@hidden_druid,@visible_druid])    
+    reindex_solr_docs([@hidden_druid,@visible_druid])
   end
-  
+
   it "should not show the visibility facet to non-curators" do
     visit root_path
     expect(page).not_to have_content("Visibility")
@@ -57,15 +57,17 @@ describe("Item Visibility",:type=>:request,:integration=>true) do
     login_as(curator_login)
     expect(page).to have_content("Visibility")
   end
-  
+
   it "should not show hidden items to non-logged in or regular users" do
     should_deny_access(@hidden_druid_path)
     login_as(user_login)
     should_deny_access(@hidden_druid_path)
     visit all_collections_path
-    expect(page).to have_content("The David Nadig Collection of The Revs Institute (14 items)")
+    expect(page).to have_content('The David Nadig Collection of The Revs Institute')
+    expect(page).to have_content('Collier Collection')
+    expect(page).to have_content('14 items')
     visit @nadig_collection_path
-    expect(page).to have_content("14 items")
+    expect(page).to have_content('14 items')
   end
 
   it "should show hidden items to curators and admins" do
@@ -73,14 +75,16 @@ describe("Item Visibility",:type=>:request,:integration=>true) do
     logins.each do |user|
       login_as(user)
       visit @hidden_druid_path
-      expect(page).to have_content("Bryar 250 Trans-American:10")
-      expect(page).to have_content("Hidden")
+      expect(page).to have_content('Bryar 250 Trans-American:10')
+      expect(page).to have_content('Hidden')
       visit all_collections_path
-      expect(page).to have_content("The David Nadig Collection of The Revs Institute (15 items)")
+      expect(page).to have_content('The David Nadig Collection of The Revs Institute')
+      expect(page).to have_content('Collier Collection')
+      expect(page).to have_content('15 items')
       visit @nadig_collection_path
-      expect(page).to have_content("15 items")
+      expect(page).to have_content('15 items')
       logout
     end
-  end  
-  
+  end
+
 end


### PR DESCRIPTION
Closes #8 

- Added label showing archive to homepage and collection detail carousel and collection results pages.
- Reordered 'archive' and 'collection' in facet sidebar and item detail metadata accordion
- Added stub for 'Filter by archive' to collections results page
- Added 'Content Donors' about page (currently commented out link to it in sidebar)

Examples:

![revs_digital_library](https://cloud.githubusercontent.com/assets/101482/7715491/8b3aeab0-fe3c-11e4-991a-b7b6cedf048f.png)
---

![revs_digital_library__collections](https://cloud.githubusercontent.com/assets/101482/7715492/91bbf230-fe3c-11e4-9c9c-08d646ab53ba.png)
---

![revs_digital_library__collections 2](https://cloud.githubusercontent.com/assets/101482/7715523/ffcb0c84-fe3c-11e4-8c4b-a42e314a4697.png)
---

![revs_digital_library__content_donors](https://cloud.githubusercontent.com/assets/101482/7715511/cefc1198-fe3c-11e4-9b7f-68462efd734f.png)

