### PR TITLE
Add metadata preview

### DIFF
--- a/app/assets/javascripts/revs.js
+++ b/app/assets/javascripts/revs.js
@@ -39,7 +39,9 @@ $(document).ready(function(){
   });
 
   // Initialize Bootstrap tooltip
-  $('.help').tooltip();
+	$(function () {
+	  $('[data-toggle="tooltip"]').tooltip();
+	});
 
   // // admin users select all
   // $( '#admin-select-all-users' ).click( function () {
@@ -150,10 +152,9 @@ $(document).ready(function(){
 			$('.score-viz-detailed .score').addClass('half-full');
 		}
 
-		// Use item metadata score vallue to update score viz for all items on results page
-		var score;
-		$('.metadata-preview .item-score').each(function() {
-			score = $(this).data('score-value');
+		// Use item metadata score value to update score viz for all items on results page
+		$('.score-preview .item-score').each(function() {
+			var score = $(this).data('score-value');
 			$(this).css('width', score);
 		});
 

--- a/app/assets/javascripts/revs.js
+++ b/app/assets/javascripts/revs.js
@@ -142,13 +142,20 @@ $(document).ready(function(){
       $('#bulk-update-button').addClass('extra-padding');
     }
 
-		// Use item metadata score value to update score visualization
+		// Use item metadata score value to update score visualization on detail page
 		var score = $('.item-score').data('score-value');
 		$('.score-viz .item-score').css('width', score);
 		$('.score-viz-detailed .item-score').css('width', score * 2);
 		if (score > 53) {
 			$('.score-viz-detailed .score').addClass('half-full');
 		}
+
+		// Use item metadata score vallue to update score viz for all items on results page
+		var score;
+		$('.metadata-preview .item-score').each(function() {
+			score = $(this).data('score-value');
+			$(this).css('width', score);
+		});
 
 		// Collections Results 'filter by archive' pulldown.
 		// Use querystring value of 'archive' to show current filter in pulldown

--- a/app/assets/stylesheets/_catalog.scss
+++ b/app/assets/stylesheets/_catalog.scss
@@ -88,9 +88,14 @@
   .zoom-image-link {
     display: block;
 
-    &.visible-phone {margin-bottom: 15px;}
+    &.visible-phone {
+      margin-bottom: 15px;
+    }
 
-    &.hidden-phone {margin-top: 20px; margin-bottom: none;}
+    &.hidden-phone {
+      margin-bottom: 0;
+      margin-top: 20px;
+    }
   }
 
   .dl-horizontal {
@@ -251,6 +256,7 @@
       }
     }
   }
+
   .item-actions {
     li:hover {
       background: $gray-lighter;
@@ -304,11 +310,14 @@
       }
     }
 
-    a:hover i, div:hover i {
+    a:hover i,
+    div:hover i {
       color: $revs-red;
     }
 
-    #annotate_link {padding: 0;}
+    #annotate_link {
+      padding: 0;
+    }
 
     a#hide_annotations_link {
       background-color: $gray-lighter;
@@ -333,8 +342,8 @@
     }
 
     #user_galleries a i {
-     margin-left: 1px;
-     margin-right: 15px;
+      margin-left: 1px;
+      margin-right: 15px;
     }
 
     #add_to_gallery_form {
@@ -373,7 +382,7 @@
         background-image: none;
         float: right;
         font-size: 1.5em;
-        margin-right: 0
+        margin-right: 0;
       }
     }
 
@@ -418,7 +427,8 @@
       }
     }
 
-    #all_flags, #all-annotations {
+    #all_flags,
+    #all-annotations {
       color: $gray;
 
       .flag-info,
@@ -681,25 +691,94 @@
 }
 
 .metadata-preview {
-  position: relative;
+  background-color: rgba(0, 0, 0, .3);
+  border-radius: 3px;
+  height: 20px;
+  margin-top: -25px;
 
-  .score-viz {
-    box-shadow: 1px 2px 6px $gray;
-    margin-left: 10px;
-    margin-top: -15px;
+  .tooltip-inner {
+    max-width: 350px;
+    padding: 0;
+    width: 350px;
+  }
 
-    .max-score {
-      opacity: .6;
+  .panel {
+    background-color: $revs-red;
+    margin-bottom: 0;
+  }
+
+  .panel-body {
+    background-color: $white;
+    text-align: left;
+
+    p {
+      margin-top: 0;
     }
   }
 
-  .fa-info-circle {
-    bottom: -3px;
-    box-shadow: 0 1px 1px $revs-gray-light;
-    color: $off-white;
-    font-size: 18px;
-    position: absolute;
-    right: 8px;
+  h3 {
+    background-color: $revs-red;
+    border-bottom: 1px solid $gray-ccc;
+    color: $white-smoke;
+    font-weight: 500;
+    margin: 0;
+    padding: 8px 14px;
+    text-align: left;
+    white-space: nowrap;
+
+    span {
+      background-color: $white-smoke;
+      border: 1px solid $gray;
+      border-radius: 15px;
+      color: $gray;
+      float: right;
+      margin-top: -3px;
+      min-width: 20px;
+      padding: 2px 4px;
+      text-align: center;
+    }
+  }
+
+  dl {
+    margin-bottom: 0;
+  }
+
+  dt {
+    color: $gray-light;
+    text-align: left;
+    width: 80px;
+  }
+
+  dd {
+    margin-left: 90px;
+  }
+
+  .score-preview {
+    display: inline-block;
+    min-width: 120px;
+    position: relative;
+
+    .score-viz {
+      box-shadow: 1px 2px 6px $gray;
+      margin-bottom: 0;
+      margin-left: 10px;
+
+      .max-score {
+        opacity: .7;
+      }
+    }
+  }
+
+  .metadata-panel-trigger {
+    display: inline-block;
+    float: right;
+    margin-right: 8px;
+
+    .fa-info-circle {
+      box-shadow: 0 1px 1px $revs-gray-light;
+      color: $off-white;
+      font-size: 18px;
+    }
   }
 }
 
@@ -725,7 +804,7 @@
   }
 }
 
-@media screen and (max-width: 991px) {
+@media screen and (max-width: $screen-sm-max) {
   .blacklight-catalog-show {
     .metadata {
       margin-bottom: 20px;
@@ -743,7 +822,7 @@
   }
 }
 
-@media screen and (max-width: 991px) and (min-width: 768px) {
+@media screen and (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
   .blacklight-catalog-show .metadata {
     margin-top: 5px;
 
@@ -764,7 +843,7 @@
   }
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: $screen-xs-max) {
   .blacklight-catalog-show {
     .carousel-container {
       margin-top: 10px;
@@ -796,5 +875,9 @@
         margin-left: 30px;
       }
     }
+  }
+
+  .metadata-preview {
+    display: none;
   }
 }

--- a/app/assets/stylesheets/_catalog.scss
+++ b/app/assets/stylesheets/_catalog.scss
@@ -680,6 +680,29 @@
   margin-top: 25px;
 }
 
+.metadata-preview {
+  position: relative;
+
+  .score-viz {
+    box-shadow: 1px 2px 6px $gray;
+    margin-left: 10px;
+    margin-top: -15px;
+
+    .max-score {
+      opacity: .6;
+    }
+  }
+
+  .fa-info-circle {
+    bottom: -3px;
+    box-shadow: 0 1px 1px $revs-gray-light;
+    color: $off-white;
+    font-size: 18px;
+    position: absolute;
+    right: 8px;
+  }
+}
+
 // Responsive styles
 
 @media screen and (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {

--- a/app/views/catalog/_document_gallery.html.erb
+++ b/app/views/catalog/_document_gallery.html.erb
@@ -7,7 +7,7 @@
         <%= render_document_partial document, :index, :document_counter => index %>
 
         <% if can? :curate, :all  %>
-          <%= render partial: 'metadata_preview', locals: {score: document.score} %>
+          <%= render partial: 'metadata_preview', locals: {document: document} %>
         <% end %>
       </li>
     <% end %>

--- a/app/views/catalog/_document_gallery.html.erb
+++ b/app/views/catalog/_document_gallery.html.erb
@@ -5,6 +5,10 @@
     <% documents.each_with_index do |document, index| %>
       <li class="image-item">
         <%= render_document_partial document, :index, :document_counter => index %>
+
+        <% if can? :curate, :all  %>
+          <%= render partial: 'metadata_preview', locals: {score: document.score} %>
+        <% end %>
       </li>
     <% end %>
   </ul>

--- a/app/views/catalog/_metadata_preview.html.erb
+++ b/app/views/catalog/_metadata_preview.html.erb
@@ -1,8 +1,70 @@
 <div class="metadata-preview">
-  <div class="score-viz">
-    <div class="max-score"></div>
-    <div class="item-score" data-score-value="<%= score %>"></div>
-  </div>
+  <a href="#" class="metadata-panel-trigger showOnLoad" data-placement="left"
+    data-title="
+      <div class='panel'>
+        <h3>
+          <%= t('revs.curator.headings.metadata_preview') %>
+          <span><%= document.score %></span>
+        </h3>
+        <div class='panel-body'>
+          <% if document.score == 0 %>
+            <p><%= t('revs.messages.no_descriptive_metadata') %></p>
+          <% else %>
+            <% unless document.description.blank? %>
+              <p><%= truncate(document.description, length: 100) %></p>
+            <% end %>
+            <dl class='dl-horizontal'>
+              <% unless document.full_date.blank? %>
+                <dt><%= t('revs.show.label_date') %>:</dt>
+                <dd><%= document.full_date %></dd>
+              <% end %>
+              <% unless document.years.blank? %>
+                <dt><%= t('revs.show.label_years') %>:</dt>
+                <dd><%= document.years.join(", ") %></dd>
+              <% end %>
+              <% unless document.location.blank? %>
+                <dt><%= t('revs.show.label_location') %>:</dt>
+                <dd><%= document.location %></dd>
+              <% end %>
+              <% unless document.people.blank? %>
+                <dt><%= t('revs.show.label_people') %>:</dt>
+                <dd><%= document.people.join("; ") %></dd>
+              <% end %>
+              <% unless document.marque.blank? %>
+                <dt><%= t('revs.show.label_marque') %>:</dt>
+                <dd><%= document.marque.join("; ") %></dd>
+              <% end %>
+              <% unless document.vehicle_model.blank? %>
+                <dt><%= t('revs.show.label_model') %>:</dt>
+                <dd><%= document.vehicle_model.join("; ") %></dd>
+              <% end %>
+              <% unless document.model_year.blank? %>
+                <dt><%= t('revs.show.label_model_year') %>:</dt>
+                <dd><%= document.model_year.join("; ") %></dd>
+              <% end %>
+              <% unless document.event.blank? %>
+                <dt><%= t('revs.show.label_event') %>:</dt>
+                <dd><%= document.event %></dd>
+              <% end %>
+              <% unless document.venue.blank? %>
+                <dt><%= t('revs.show.label_venue') %>:</dt>
+                <dd><%= document.venue %></dd>
+              <% end %>
+            <% end %>
+          </dl>
+        </div>
+      </div>
+      "
+    data-toggle="tooltip"
+    data-html="true"
+    data-original-title=""  title="">
+    <i class="fa fa-info-circle"></i>
+  </a>
 
-  <i class="fa fa-info-circle"></i>
+  <div class="score-preview">
+    <div class="score-viz">
+      <div class="max-score"></div>
+      <div class="item-score" data-score-value="<%= document.score %>"></div>
+    </div>
+  </div>
 </div>

--- a/app/views/catalog/_metadata_preview.html.erb
+++ b/app/views/catalog/_metadata_preview.html.erb
@@ -1,0 +1,8 @@
+<div class="metadata-preview">
+  <div class="score-viz">
+    <div class="max-score"></div>
+    <div class="item-score" data-score-value="<%= score %>"></div>
+  </div>
+
+  <i class="fa fa-info-circle"></i>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
       public_visibility_show: "Show this item to the public"
       public_visibility_hide: "Hide this item from public view"
       you: 'you'
+      no_descriptive_metadata: "This item has no descriptive metadata."
     flags:
       anonymous_not_shown: 'Flags added anonymously are not shown.'
       refresh_list: 'Refresh list'
@@ -343,6 +344,7 @@ en:
         action: "Action"
         field_to_update: "Field to update"
         field_value: "Field value"
+        metadata_preview: "Metadata preview"
     dashboards: 'Dashboards'
     citations:
         view: 'View full citation page'


### PR DESCRIPTION
Closes #18

For curators only, show preview of metadata score as overlay on item images. Also show info icon. Hovering over icon shows an overlay panel with the current values of the most important metadata fields for the item.

Labels for fields with null values aren't shown. If an item has a metadata score of 0, the overlay displays a message saying that the item has no descriptive metadata yet.

### Results page with preview score and info icon

![revs_digital_library__search](https://cloud.githubusercontent.com/assets/101482/8120277/361db030-1052-11e5-8750-277941c02146.png)

### After hovering over an item's info icon

![revs_digital_library__search 2](https://cloud.githubusercontent.com/assets/101482/8120278/3a0809ac-1052-11e5-9b6e-463b396e838b.png)
