### PR TITLE
Show hidden edits to curators

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -46,7 +46,7 @@ class UserController < ApplicationController
   # all of the user's item edits
   def edits
     @order="change_logs.#{@order}" if @order == 'created_at desc'
-    @edits=@user.change_logs.order(@order).page(@current_page).per(@per_page)
+    @edits=@user.metadata_updates(current_user).order(@order).page(@current_page).per(@per_page)
     @page_title="#{@user.to_s}: #{I18n.t('revs.curator.edits')}"
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -174,7 +174,7 @@ module ApplicationHelper
   end
 
   def edits_count(user)
-    user.metadata_updates.count
+    user.metadata_updates(current_user).count
   end
 
   def flags_unresolved_count(user)

--- a/spec/features/curator_spec.rb
+++ b/spec/features/curator_spec.rb
@@ -85,7 +85,7 @@ describe("Curator Section",:type=>:request,:integration=>true) do
       login_as(curator_login)
       visit edits_table_curator_tasks_path
       expect(current_path).to eq(edits_table_curator_tasks_path)
-      edited_users=["Curator Revs 4","admin1 1"]
+      edited_users=["Curator Revs 5","admin1 1"]
       edited_users.each {|title| expect(page).to have_content(title)}
       expect(page).to have_content 'By Item'
       expect(page).to have_content 'By User'

--- a/test/fixtures/change_logs.yml
+++ b/test/fixtures/change_logs.yml
@@ -18,7 +18,7 @@ changelog2:
   operation: 'metadata update'
   updated_at: 6/1/2013
   created_at: 6/1/2013
-          
+
 changelog3:
    user: curator  # this is the named "curator" fixture object from the users table
    druid: 'bg152pb0116'
@@ -40,3 +40,9 @@ changelog5:
   updated_at: 6/4/2013
   created_at: 6/4/2013
 
+changelog6:
+  user: curator  # this is the named "curator" fixture object from the users table
+  druid: 'bb004bn8654' # this is a hidden item with an edit
+  operation: 'metadata update'
+  updated_at: 6/4/2014
+  created_at: 6/4/2014


### PR DESCRIPTION
On profile pages, metadata edits made to hidden items should be shown on user's profile pages if you are logged in as a curator/admin (someone who is otherwise allowed to see hidden images) while remaining hidden for everyone else.  This wasn't working correctly (as it was for annotated hidden images and favorited hidden images) and this code fixes it.

@ggeisler 