### PR TITLE
when logged in as a curator, sort the "more items" area at the bottom…

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -173,11 +173,13 @@ class CatalogController < ApplicationController
   def show_collection_members_grid
     @document=SolrDocument.find(params[:id])
     if params[:on_page] == 'item'
-      @collection_members=@document.siblings(:random=>true,:include_hidden=>can?(:view_hidden, SolrDocument))
+      sort = (user_signed_in? && current_user.curator?) ? "score" : "random"
+      @collection_members=@document.siblings(:sort=>sort,:include_hidden=>can?(:view_hidden, SolrDocument))
       @type=:siblings
       @show_full_width=true
     else
-      @collection_members=@document.collection_members(:include_hidden=>can?(:view_hidden, SolrDocument))
+      sort = (user_signed_in? && current_user.curator?) ? "score" : "priority"
+      @collection_members=@document.collection_members(:sort=>sort,:include_hidden=>can?(:view_hidden, SolrDocument))
       @type=:collection
       @show_full_width=false
     end

--- a/app/views/collection/_detailed.html.erb
+++ b/app/views/collection/_detailed.html.erb
@@ -2,7 +2,7 @@
 
   <% @collections.each_with_index do |collection, counter|
 
-      collection_members = collection.collection_members(:rows => @num_to_show_in_filmstrip, :random=>true, :include_hidden=>can?(:view_hidden, SolrDocument))
+      collection_members = collection.collection_members(:rows => @num_to_show_in_filmstrip, :sort=>"random", :include_hidden=>can?(:view_hidden, SolrDocument))
      %>
     <div class="blacklight-collection document row<%= " first" if counter == 0 %>">
       <div class="col-xs-12 collection-title">

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -30,7 +30,7 @@ describe SolrDocument do
         expect(SolrDocument.new({:id => "12345"}).is_item?).to be_falsey
         expect(SolrDocument.new({:"is_member_of_ssim" => "collection-1"}).is_item?).to be_truthy
       end
-      it "should memoize the solr request to get collection members" do
+      it "should memorize the solr request to get collection members" do
         response = {"response" => {"numFound" => 3, "docs" => [{:id=>"1234"}, {:id =>"4321"}]}}
         connection = double("connection")
         expect(connection).to receive(:select).with(:params => {:fq=>"is_member_of_ssim:\"collection-1\" AND ((*:* -visibility_isi:[* TO *]) OR visibility_isi:1)", :sort=>"priority_isi desc",:rows => "20",:start=>"0"}).once.and_return(response)


### PR DESCRIPTION
… of the page by metadata score, showing items that need work, instead of randomly

fixes #66 