### PR TITLE
add new logic to allow for a different special rights statement

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -32,6 +32,10 @@ class AboutController < ApplicationController
   # this is the special contact us page
   def contact
 
+    @from=params[:from]
+    @subject=params[:subject]
+    @message=params[:message]
+
     show
 
   end
@@ -58,7 +62,7 @@ class AboutController < ApplicationController
     else
 
       if valid_submission?
-      
+
         if @subject=='metadata'  # don't bother creating a jira ticket for a metadata update, since we will create an anonymous flag anyway and add the email address and name into a private comment
           flash[:notice]=t("revs.about.contact_message_sent_about_metadata")
           unless @from.blank? # create a flag for this if its feedback that is coming from a specific druid page

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -145,28 +145,6 @@ class CatalogController < ApplicationController
       @saved_items=@gallery.saved_items(current_user).limit(CatalogController.blacklight_config.collection_member_grid_items)
     end
 
-    # some logic around the display of reproduction statements which is special for revs items and includes contact links, which is why it is not in the model
-    if @document && @document.revs_item? && !@document.reproduction_not_available?
-
-      @use_and_reproduction=""
-      @use_and_reproduction += I18n.t('revs.contact.image_reuse_agreement',
-          :license_agreement_link => ActionController::Base.helpers.link_to(t('revs.contact.image_license_agreement'),
-          Revs::Application.config.revs_reuse_link,:target=>'_new')).html_safe
-      @use_and_reproduction += I18n.t('revs.contact.reuse_contact',
-          :reuse_contact_link => ActionController::Base.helpers.link_to(t('revs.contact.contact_linktext_html'),
-          contact_us_path(:subject=>'terms of use',
-                          :from=>request.path,
-                          :message=> t('revs.contact.reuse_contact_message',
-                            :reuse_contact_message_doc => @document.identifier,
-                            :reuse_contact_message_url => catalog_url(@document.id)
-          )))).html_safe
-
-    elsif @document
-
-      @use_and_reproduction = @document.use_and_reproduction
-
-    end
-
   end
 
   # an ajax call to show just the collection members grid at the bottom of the page

--- a/app/views/about/_contact.html.erb
+++ b/app/views/about/_contact.html.erb
@@ -9,7 +9,7 @@
 	<%= hidden_field_tag 'auto_response',@auto_response || true%>
 	<%= hidden_field_tag 'loadtime',Time.now%>
 
-	<% if Revs::Application.config.contact_us_topics.size > 1 %>
+  <% if Revs::Application.config.contact_us_topics.size > 1 %>
 		<div class="form-group">
 		  <label class="control-label col-xs-12 col-sm-3 col-md-2" for="subject"><%=t('revs.contact.subject')%></label>
 		  <div class="col-xs-8 col-sm-6 col-md-5">

--- a/app/views/catalog/_show_collection_member.html.erb
+++ b/app/views/catalog/_show_collection_member.html.erb
@@ -15,7 +15,7 @@
                                          'availableSizes': [<%=raw available_sizes%>],
                                          'zoomOnClick': true,
                                          'disableKeyboardShortcuts': true,
-                                         'displayNote': '<%=@document.copyright %> <%= @use_and_reproduction.html_safe %>',
+                                         'displayNote': '<%=@document.copyright %> <%= @document.use_and_reproduction.html_safe %>',
                                          'showDisplayNoteOnlyOnFullScreen': true,
                                      'tooltipTexts': {
                                      '<%= I18n.locale %>': {
@@ -277,7 +277,7 @@
 
         <div class="license-image">
           <%=@document.copyright %>
-          <%=@use_and_reproduction.html_safe %>
+          <%=@document.use_and_reproduction.html_safe %>
         </div>
 
       </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,18 +88,23 @@ module Revs
 
     # these collections are only available for non-commerical reproduction and will show a special statement instead of the use and reproduction statement in the item itself
     config.collections_available_for_noncommerical_reproduction =
-      ['td221fy0182',
-        'jh550nq3200',
-        'ch493nk3954',
-        'zg796vp9147',
-        'qn776mq9014',
-        'vm027cv8758',
-        'wt886dn0556',
-        'my206bq1956',
-        'wz243gf4151']
+      [ 'jh550nq3200', # Worner
+        'zq905ny4367', # Grand Prix
+        'ch493nk3954', # Tubbs
+        'zg796vp9147', # European Motorsport
+        'qn776mq9014', # Cabart
+        'vm027cv8758', # Richley
+        'wt886dn0556', # Derauw
+        'wz243gf4151', # Chambers
+        'my206bq1956'  # Royal Automobile Trophy
+      ]
 
-    # these collections are only available for non-commerical reproduction or special permission granted and will show a special statement instead of the use and reproduction statement in the item itself
-    config.collections_available_for_noncommerical_reproduction_or_permission = []
+    # these collections have uncertain rights and we will show a special statement instead of the use and reproduction statement in the item itself
+    config.collection_rights_uncertain =
+      [ 'td221fy0182', # Breslauer
+        'gw676ck6589', # Ludvigsen
+        'yt502zj0924', # Craig
+      ]
 
     config.revs_reuse_link='http://revsinstitute.org/order-images/'
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -86,8 +86,20 @@ module Revs
     config.contact_us_recipients = {'default'=>'digcoll@jirasul.stanford.edu', 'terms of use'=>'ldrake@chmotorcars.com','metadata'=>'digcoll@jirasul.stanford.edu','error'=>'digcoll@jirasul.stanford.edu','other'=>'digcoll@jirasul.stanford.edu','special collections'=>'specialcollections@stanford.edu'} # sets the email address for each contact us topic configed aboveend
     config.contact_us_cc_recipients = {'default'=>'revs-other@jirasul.stanford.edu', 'metadata'=>'revs-metadata-comment@jirasul.stanford.edu', 'error'=>'revs-problems@jirasul.stanford.edu','other'=>'revs-other@jirasul.stanford.edu'} # sets the CC email address for each contact us topic configed above
 
-    # these collections are not available for reproduction and will show a special statement instead of the use and reproduction statement in the item itself...currently Breslauer, Bochroch, Worner, Cabart, Chambers, Derauw, European Motorsport in the 1950s and 1960s, Richley, Thomas, Tubbs
-    config.collections_not_available_for_reproduction = ['td221fy0182','jh550nq3200','ch493nk3954','zg796vp9147','qn776mq9014','vm027cv8758','wt886dn0556','my206bq1956','wz243gf4151']
+    # these collections are only available for non-commerical reproduction and will show a special statement instead of the use and reproduction statement in the item itself
+    config.collections_available_for_noncommerical_reproduction =
+      ['td221fy0182',
+        'jh550nq3200',
+        'ch493nk3954',
+        'zg796vp9147',
+        'qn776mq9014',
+        'vm027cv8758',
+        'wt886dn0556',
+        'my206bq1956',
+        'wz243gf4151']
+
+    # these collections are only available for non-commerical reproduction or special permission granted and will show a special statement instead of the use and reproduction statement in the item itself
+    config.collections_available_for_noncommerical_reproduction_or_permission = []
 
     config.revs_reuse_link='http://revsinstitute.org/order-images/'
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,7 +1,7 @@
 Revs::Application.configure do
 
   config.eager_load = false
-  
+
   # Settings specified here will take precedence over those in config/application.rb
   config.exception_error_page = false # show a friendly 500 error page if true
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
@@ -35,7 +35,7 @@ Revs::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
-  # Revs App Configuration  
+  # Revs App Configuration
   config.simulate_sunet_user = "sunetuser" # SET TO BLANK OR FALSE IN PRODUCTION (it should be ignored in production anyway) if this has a value, then this will simulate you being logged in as a sunet user
   config.purl_plugin_server = "test"
   config.purl_plugin_location = "//image-viewer.stanford.edu/assets/purl_embed_jquery_plugin.js"
@@ -45,4 +45,5 @@ Revs::Application.configure do
   config.show_galleries_in_nav = true # if set to true, then galleries is shown in top navigation
 
   config.featured_contributors=['curator1','admin1','user1'] # array of usernames of featured contributors for about top contributors page...will be shown in this order, use an empty array if none
+
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,15 +213,12 @@ en:
       message: 'Message'
       spambot_label: 'Leave blank'
       spambot: 'Please leave this field blank - it is used to prevent spam submissions'
-      default_revs_copyright: "Courtesy of The Revs Institute for Automotive Research, Inc. All rights reserved unless otherwise indicated."
-      image_available_for_noncommercial_use_only: "Due to copyright restrictions, this item is not available for reproduction."
-      image_available_for_noncommercial_use_only_contact_us: "This item is not available for reproduction for commerical use.  Contact us for non-commerical use."
+      default_revs_copyright: "Courtesy of The Revs Institute. All rights reserved unless otherwise indicated."
+      image_reuse_agreement: "To request this image for commercial or non-commercial use, please contact "
+      contact_linktext_html: "The Revs Institute."
+      image_available_for_noncommercial_use_only: "Due to copyright restrictions, this item is available for non-commercial use only. To request this image, please contact "
+      image_uncertain: "Due to copyright restrictions, this item may not be available for commercial use. To request this image, please contact "
       describe_problem: 'Please describe your question or problem.'
-      image_license_agreement: "permission to use requirements "
-      image_reuse_agreement: "To request access or purchase this image, please review the %{license_agreement_link}"
-      reuse_contact: "and contact %{reuse_contact_link}"
-      contact_linktext_html: "The Revs Institute for Automotive Research, Inc."
-      reuse_contact_message: "Request to purchase image image ID %{reuse_contact_message_doc} at %{reuse_contact_message_url}"
       thanks: 'Thanks for contacting the Revs Digital Library'
     authentication:
       new_user: 'New user?'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,8 +214,8 @@ en:
       spambot_label: 'Leave blank'
       spambot: 'Please leave this field blank - it is used to prevent spam submissions'
       default_revs_copyright: "Courtesy of The Revs Institute for Automotive Research, Inc. All rights reserved unless otherwise indicated."
-      default_revs_rights_statement: "Users must contact The Revs Institute for Automotive Research, Inc. for re-use and reproduction information."
-      image_not_available_for_reproduction: "Due to copyright restrictions, this item is not available for reproduction."
+      image_available_for_noncommercial_use_only: "Due to copyright restrictions, this item is not available for reproduction."
+      image_available_for_noncommercial_use_only_contact_us: "This item is not available for reproduction for commerical use.  Contact us for non-commerical use."
       describe_problem: 'Please describe your question or problem.'
       image_license_agreement: "permission to use requirements "
       image_reuse_agreement: "To request access or purchase this image, please review the %{license_agreement_link}"

--- a/config/templates/mods_template.xml
+++ b/config/templates/mods_template.xml
@@ -44,6 +44,13 @@
 			</subject>
 		<% end %>
   <% end %>
+  <% [:people1,:people2,:people3,:people4,:people5,:people6,:people7,:people8,:people9,:people10].each do |alt_people_col| %>
+    <% if !manifest_row[alt_people_col].blank? %>
+      <subject displayLabel="People" authority="local">
+        <name type="personal"><namePart><%=manifest_row[alt_people_col].strip%></namePart></name>
+      </subject>
+    <% end %>
+  <% end %>
 	<% if !manifest_row[:entrant].blank? %>
 	  <% manifest_row[:entrant].split('|').each do |entrant| %>
   		<subject id="entrant" displayLabel="Entrant" authority="local">

--- a/spec/features/models/solr_document_spec.rb
+++ b/spec/features/models/solr_document_spec.rb
@@ -5,14 +5,15 @@ describe SolrDocument, :integration => true do
   describe "rights and copyright" do
     it "should set the correct speciality revs rights statement even if rights found in solr document" do
       doc=SolrDocument.find('bb004bn8654') # fixture with no copyright or rights specified
-      expect(doc.use_and_reproduction).to eq("To request access or purchase this image, please review the <a target=\"_new\" href=\"http://revsinstitute.org/order-images/\">permission to use requirements </a>and contact <a href=\"/contact?from=%2Fcatalog%2Fbb004bn8654&amp;message=Request+to+purchase+image+image+ID+2012-027NADI-1966-b1_4.3_0015+at+https%3A%2F%2Frevslib.stanford.edu%2Fcatalog%2Fbb004bn8654&amp;subject=terms+of+use\">The Revs Institute for Automotive Research, Inc.</a>")
-      expect(doc.copyright).to eq("Courtesy of The Revs Institute for Automotive Research, Inc. All rights reserved unless otherwise indicated.") # default copyright
+      expect(doc.use_and_reproduction).to eq("To request this image for commercial or non-commercial use, please contact <a target=\"_new\" href=\"http://revsinstitute.org/order-images/\">The Revs Institute.</a>")
+      expect(doc.copyright).to eq("Courtesy of The Revs Institute. All rights reserved unless otherwise indicated.") # default copyright
     end
 
-    it "should retrieve the copyright statements if found in solr document" do
+    it "should set the default copyright statement for a revs item even if found in solr document" do
       doc=SolrDocument.find('td830rb1584') # fixtures with values specified
-      expect(doc.use_and_reproduction).to eq("To request access or purchase this image, please review the <a target=\"_new\" href=\"http://revsinstitute.org/order-images/\">permission to use requirements </a>and contact <a href=\"/contact?from=%2Fcatalog%2Ftd830rb1584&amp;message=Request+to+purchase+image+image+ID+2012-027NADI-1966-b1_2.0_0021+at+https%3A%2F%2Frevslib.stanford.edu%2Fcatalog%2Ftd830rb1584&amp;subject=terms+of+use\">The Revs Institute for Automotive Research, Inc.</a>")
-      expect(doc.copyright).to eq("This is the copyright statement - different from default.")
+      expect(doc.use_and_reproduction).to eq("To request this image for commercial or non-commercial use, please contact <a target=\"_new\" href=\"http://revsinstitute.org/order-images/\">The Revs Institute.</a>")
+      expect(doc['copyright_ss']).to eq("This is the copyright statement - different from default.")
+      expect(doc.copyright).to eq("Courtesy of The Revs Institute. All rights reserved unless otherwise indicated.") # default copyright
     end
 
     it "should retrieve the rights and copyright statement from the solr document for non-revs items but blank out the copyright statement" do
@@ -23,19 +24,19 @@ describe SolrDocument, :integration => true do
     end
     it "should set the specialty rights statement for not available for commercial reproduction for a collection specified to have one" do
       doc=SolrDocument.find('xg271zb5261') # a revs item with special rights
-      expect(doc.use_and_reproduction).to eq("Due to copyright restrictions, this item is not available for reproduction.") # special statement
-      expect(doc.copyright).to eq("Courtesy of The Revs Institute for Automotive Research, Inc. All rights reserved unless otherwise indicated.") # default copyright
+      expect(doc.use_and_reproduction).to eq("Due to copyright restrictions, this item is available for non-commercial use only. To request this image, please contact <a target=\"_new\" href=\"http://revsinstitute.org/order-images/\">The Revs Institute.</a>") # special statement
+      expect(doc.copyright).to eq("Courtesy of The Revs Institute. All rights reserved unless otherwise indicated.") # default copyright
     end
     it "should set the specialty rights statement for not available for commercial reproduction without contacinting us for a collection specified to have one" do
       previous_collections_available_for_noncommerical_reproduction = Revs::Application.config.collections_available_for_noncommerical_reproduction
-      previous_collections_available_for_noncommerical_reproduction_or_permission = Revs::Application.config.collections_available_for_noncommerical_reproduction_or_permission
-      Revs::Application.config.collections_available_for_noncommerical_reproduction_or_permission = ['wz243gf4151'] # manually set this item's collection as a special one just for the test
+      previous_collection_rights_uncertain = Revs::Application.config.collection_rights_uncertain
+      Revs::Application.config.collection_rights_uncertain = ['wz243gf4151'] # manually set this item's collection as a special one just for the test
       Revs::Application.config.collections_available_for_noncommerical_reproduction = []
       doc=SolrDocument.find('xg271zb5261') # a revs item with special rights
-      expect(doc.use_and_reproduction).to eq("This item is not available for reproduction for commerical use.  Contact us for non-commerical use.") # special statement
-      expect(doc.copyright).to eq("Courtesy of The Revs Institute for Automotive Research, Inc. All rights reserved unless otherwise indicated.") # default copyright
+      expect(doc.use_and_reproduction).to eq("Due to copyright restrictions, this item may not be available for commercial use. To request this image, please contact <a target=\"_new\" href=\"http://revsinstitute.org/order-images/\">The Revs Institute.</a>") # special statement
+      expect(doc.copyright).to eq("Courtesy of The Revs Institute. All rights reserved unless otherwise indicated.") # default copyright
       Revs::Application.config.collections_available_for_noncommerical_reproduction = previous_collections_available_for_noncommerical_reproduction
-      Revs::Application.config.collections_available_for_noncommerical_reproduction_or_permission = previous_collections_available_for_noncommerical_reproduction_or_permission
+      Revs::Application.config.collection_rights_uncertain = previous_collection_rights_uncertain
     end
 
   end

--- a/spec/fixtures/bd969sj1904.xml
+++ b/spec/fixtures/bd969sj1904.xml
@@ -38,4 +38,6 @@
   <field name="image_id_ssm">bd969sj1904_00_0030</field>
   <field name="visibility_isi">1</field>
   <field name="score_isi">0</field>
+  <field name="copyright_ss">This is the Road and Track copyright statement.</field>
+  <field name="use_and_reproduction_ss">This is the Road and Track use and reproduction statement.</field>
 </doc>

--- a/spec/fixtures/wz243gf4151.xml
+++ b/spec/fixtures/wz243gf4151.xml
@@ -1,0 +1,9 @@
+<doc>
+  <field name="id">wz243gf4151</field>
+  <field name="title_tsi">The Marcus Chambers Photograph Collection of The Revs Institute</field>
+  <field name="format_ssim">collection</field>
+  <field name="highlighted_ssi">true</field>
+  <field name="description_tsim">The Marcus Chambers Photograph Collection includes nearly 300 racing and rally images taken by Chambers when he was the Race Program Director for the British Motor Corporation (BMC) in the 1950s and 1960s. This collection includes color images of noted women race drivers.</field>
+  <field name="archive_ssi">Revs Institute® Archives</field>
+  <field name="score_isi">10</field>
+</doc>

--- a/spec/fixtures/xg271zb5261.xml
+++ b/spec/fixtures/xg271zb5261.xml
@@ -1,0 +1,13 @@
+<doc>
+  <field name="id">xg271zb5261</field>
+  <field name="title_tsi">Geneva Motor Show</field>
+  <field name="pub_year_isim">1970</field>
+  <field name="pub_year_single_isi">1970</field>
+  <field name="format_ssim">color transparencies</field>
+  <field name="is_member_of_ssim">wz243gf4151</field>
+  <field name="source_id_ssi">2011-023Cham-16.0_0001</field>
+  <field name="collection_ssim">Marcus Chambers Photograph Collection</field>
+  <field name="archive_ssi">Revs Institute® Archives</field>
+  <field name="image_id_ssm">2011-023Cham-16.0_0001</field>
+  <field name="score_isi">17</field>
+</doc>


### PR DESCRIPTION
add new logic to allow for a different special rights statement per collection
consolidate logic in model instead of controller

fix bug in about contact us page that was preventing pre-population of form fields

update mods XML template to allow for individual people columns 

NOTE: waiting for a list of collections in each category and the actual text to show