### PR TITLE
Ensure tooltip for metadata preview can be triggered

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,6 +403,3 @@ DEPENDENCIES
   thin
   uglifier (>= 1.0.3)
   whenever
-
-BUNDLED WITH
-   1.13.3

--- a/app/assets/stylesheets/_catalog.scss
+++ b/app/assets/stylesheets/_catalog.scss
@@ -695,6 +695,7 @@
   border-radius: 3px;
   height: 20px;
   margin-top: -25px;
+  position: absolute;
 
   .tooltip-inner {
     max-width: 350px;

--- a/app/assets/stylesheets/_search_results.scss
+++ b/app/assets/stylesheets/_search_results.scss
@@ -41,6 +41,7 @@
       margin-left: 10px;
       margin-right: 10px;
       min-height: 169px;
+      min-width: 187px;
       overflow: hidden;
 
       img {

--- a/app/views/catalog/_metadata_preview.html.erb
+++ b/app/views/catalog/_metadata_preview.html.erb
@@ -1,7 +1,7 @@
 <div class="metadata-preview">
 
   <% if document.score > 1 # only show icon/panel if score is greater than 0 %>
-    <a href="#" class="metadata-panel-trigger showOnLoad" data-placement="left"
+    <a href="javascript:void(0)" class="metadata-panel-trigger showOnLoad" data-placement="left"
       data-title="
         <div class='panel'>
           <h3>


### PR DESCRIPTION
For some reason the metadata preview icon and associated tooltip trigger became inaccessible at some point. This PR just adds some CSS to ensure the metadata preview div is positioned above the associated image, and that the div that holds the image is wide enough (taking into account narrow images) to enable the full metadata preview to be visible without overlapping its neighbor.

## Before
![revs_digital_library__search 2](https://cloud.githubusercontent.com/assets/101482/22074579/0ead35c4-dd66-11e6-8d04-6883b15daf9d.png)

## After
![revs_digital_library__search](https://cloud.githubusercontent.com/assets/101482/22074581/1186fd02-dd66-11e6-8d24-fb3f52080ea6.png)

