### PR TITLE
add source ids to tables to facilitate matching after export to Revs; bulk export

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,4 +415,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.6
+   1.15.2

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -8,6 +8,7 @@ class Annotation < WithSolrDocument
   belongs_to :item, :foreign_key=>:druid, :primary_key=>:druid
     
   after_create :add_annotation_to_solr
+  before_create :update_source_id
   after_update :update_annotation_in_solr
   after_destroy :update_annotation_in_solr
   after_save :update_item

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -9,6 +9,7 @@ class Flag < WithSolrDocument
 
   FLAG_STATES={ open: 'open', fixed: 'fixed', review: 'review', wont_fix: 'wont fix'}  #add a potential spam state here if desired
 
+  before_create :update_source_id
   after_save :update_item
 
   validates :druid, :is_druid=>true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,12 +1,11 @@
 class Item < WithSolrDocument
-
- attr_accessor :solr_document
     
  has_many :annotations, :foreign_key=>:druid, :primary_key=>:druid
  has_many :flags, :foreign_key=>:druid, :primary_key=>:druid
  has_many :saved_items, :foreign_key=>:druid, :primary_key=>:druid
  has_many :change_logs, :foreign_key=>:druid, :primary_key=>:druid
  
+  before_create :update_source_id
   validates :druid, :is_druid=>true
   validates :druid, :uniqueness=>true
   validate :check_visibility_value

--- a/app/models/saved_item.rb
+++ b/app/models/saved_item.rb
@@ -6,6 +6,7 @@ class SavedItem < WithSolrDocument
   include RankedModel
   ranks :row_order,:column => :position, :with_same => :gallery_id
   
+  before_create :update_source_id
   after_save :update_gallery_last_updated
   after_save :update_item
 

--- a/app/models/with_solr_document.rb
+++ b/app/models/with_solr_document.rb
@@ -4,6 +4,10 @@ class WithSolrDocument < ActiveRecord::Base
      @solr_document ||= SolrDocument.find(druid)
   end
 
+  def update_source_id
+    self.source_id = self.solr_document['source_id_ssi']
+  end
+  
   def update_item
     solr_document.update_item
   end

--- a/db/migrate/20170601224210_add_source_id.rb
+++ b/db/migrate/20170601224210_add_source_id.rb
@@ -1,0 +1,8 @@
+class AddSourceId < ActiveRecord::Migration
+  def change
+    add_column :annotations, :source_id, :string
+    add_column :flags, :source_id, :string
+    add_column :items, :source_id, :string
+    add_column :saved_items, :source_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160928213450) do
+ActiveRecord::Schema.define(version: 20170601224210) do
 
   create_table "annotations", force: :cascade do |t|
     t.integer  "user_id"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20160928213450) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.integer  "image_number", default: 0
+    t.string   "source_id"
   end
 
   add_index "annotations", ["druid"], name: "index_annotations_on_druid"
@@ -64,6 +65,7 @@ ActiveRecord::Schema.define(version: 20160928213450) do
     t.string   "state",              default: "open"
     t.string   "notification_state"
     t.text     "private_comment"
+    t.string   "source_id"
   end
 
   add_index "flags", ["druid"], name: "index_flags_on_druid"
@@ -100,6 +102,7 @@ ActiveRecord::Schema.define(version: 20160928213450) do
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
     t.string   "title",            limit: 400
+    t.string   "source_id"
   end
 
   add_index "items", ["druid"], name: "index_items_on_druid", unique: true
@@ -121,6 +124,7 @@ ActiveRecord::Schema.define(version: 20160928213450) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.integer  "position"
+    t.string   "source_id"
   end
 
   add_index "saved_items", ["druid"], name: "index_saved_items_on_druid"

--- a/lib/tasks/bulk_export.rake
+++ b/lib/tasks/bulk_export.rake
@@ -9,85 +9,117 @@ require 'revs-utils'
 require 'nokogiri'
 $stdout.sync = true
 
-namespace :revs do
-  desc "Export all metadata for a given collection to CSV - used to facilitate transfer of revs content to contentDM"
-  # https://www.oclc.org/support/services/contentdm/help/project-client-help/entering-metadata/using-tab-delimited-text-files.en.html
-  #Run Me: RAILS_ENV=production bundle exec rake revs:export_metadata_to_csv collection="John Dugdale Collection" # must be limited to a collection
-  #Run Me: RAILS_ENV=production bundle exec rake revs:export_metadata_to_csv collection="John Dugdale Collection" limit=100 # optionally sets a limit of number of items
-  #Run Me: RAILS_ENV=production nohup bundle exec rake revs:export_metadata_to_csv collection="John Dugdale Collection" > export.log 2>&1& # nohup mode with logged output
+def cleanup_export_value(input_value,delimiter,delimiter_replace)
+    return nil if input_value.blank?
+    value = input_value.to_s
+    value.gsub! /\t/, '  ' # remove tabs
+    value.gsub! /\n/, '  ' # remove CRs
+    value.gsub! /\r/, '  ' # remove linefeeds
+    value.gsub! delimiter.strip, delimiter_replace # convert delimiter to a different character in the values to prevent problems
+    value
+end
 
-  task :export_metadata_to_csv  => :environment do |t, args|
+namespace :revs do
+  desc "Export all metadata for a given collection to TXT - used to facilitate transfer of revs content to contentDM"
+  # https://www.oclc.org/support/services/contentdm/help/project-client-help/entering-metadata/using-tab-delimited-text-files.en.html
+  # You *must* provide a collection.
+  #Run Me: RAILS_ENV=production bundle exec rake revs:export_metadata_to_txt collection="John Dugdale Collection" # must be limited to a collection
+  #Run Me: RAILS_ENV=production bundle exec rake revs:export_metadata_to_txt collection="John Dugdale Collection" limit=100 # optionally sets a limit of number of items (defaults to no limit)
+  #Run Me: RAILS_ENV=production bundle exec rake revs:export_metadata_to_txt collection="John Dugdale Collection" rows=1000 # optionally sets maximum number of rows per spreadsheet (autosplit based on this number, defaults to 1000)
+  #Run Me: RAILS_ENV=production bundle exec rake revs:export_metadata_to_txt collection="John Dugdale Collection" visibility="visible" # only visible images are exported (defaults to "all", can also pass "hidden")
+  #Run Me: RAILS_ENV=production nohup bundle exec rake revs:export_metadata_to_txt collection="John Dugdale Collection" > export.log 2>&1& # nohup mode with logged output
+
+  task :export_metadata_to_txt  => :environment do |t, args|
 
     limit = ENV['limit'] || '' # if passed, limits to this many items only
-    collection = ENV['collection'] || '' # if passed, limits to this collection only
+    max_rows = ENV['max_rows'] || 1000 # if passed, limits to this many items only
+    collection = ENV['collection'] || '' # limits to this collection only
+    visibility = ENV['visibility'] || "all" # can be passed as "all" (default), "visible" or "hidden".  
+
     raise "you must provide a collection" if collection.blank?
     
     q="*:*"
     q+=" AND collection_ssim:\"#{collection}\"" 
-
+    case visibility
+       when "visible"
+         q+= " AND -visibility_isi:#{SolrDocument.visibility_mappings[:hidden]}"
+       when "hidden"
+         q+= " AND visibility_isi:#{SolrDocument.visibility_mappings[:hidden]}"
+     end
+    puts q
     rows = limit.blank? ? "1000000" : limit
 
     @all_docs = Blacklight.default_index.connection.select(:params => {:q => q, :fl=>'id', :rows=>rows})
     total_docs=@all_docs['response']['docs'].size
 
     start_time=Time.now
-    n=0
+    n=1
+    file_number=0
     num_errors=0
-    output_file = "log/#{collection.gsub(" ","_")}_#{Time.now.strftime('%Y-%m-%dT%H:%M:%S.%LZ')}.txt"
-
+    delimiter = "; " # delimiter for multivalued fields
+    delimiter_replace = "," # when the delimiter exists in actual values, it will replaced with this character
+    max_rows = max_rows.to_i # maximum number of rows in any given spreadsheet
+    excluded_fields = ['car_group','car_class','group_class','timestamp','priority','resaved_at','identifier','single_year','archive_name','collections','highlighted','subjects'] # exclude these fields in output
+    csv = nil
+    
+    base_output_file = "log/#{collection.gsub(" ","_")}_#{visibility}_#{Time.now.strftime('%Y-%m-%dT%H:%M:%S.%LZ')}" # base name for output file(s)
+  
     puts ""
     puts "Started at #{start_time}, #{total_docs} docs returned"
     puts " limited to collection: #{collection}" 
     puts " limited to #{limit} items" unless limit.blank?
     puts " found #{total_docs} items"
-
+    puts " maximum rows per file: #{max_rows}"
+    puts " visibility: #{visibility}"
     puts ""
-    puts q
-    puts ""
 
-    CSV.open(output_file, "wb", {:col_sep => "\t"}) do |csv|
+    number_of_files = (total_docs.to_f / max_rows).ceil
 
-      revs_field_mappings = SolrDocument.new.revs_field_mappings.with_indifferent_access
-      excluded_fields = ['resaved_at','identifier','single_year','archive_name','collections','highlighted'] # exclude these
+    revs_field_mappings = SolrDocument.new.revs_field_mappings.with_indifferent_access
+    header_row = []
+    revs_field_mappings.each { |field, config| header_row << field.to_s unless excluded_fields.include? field.to_s } # write out all fields to the header that are not excluded
 
-      header_row = []
-      revs_field_mappings.each { |field, config| header_row << field.to_s unless excluded_fields.include? field.to_s } # write out all fields to the header
-      csv << ['druid','identifier'] + header_row + ['filename'] # add extra columns we need
+    @all_docs['response']['docs'].each do |doc|
 
-      @all_docs['response']['docs'].each do |doc|
-
-        id=doc['id']
-        n+=1
-        puts "#{n} of #{total_docs}: #{id}"
-         begin
-           s=SolrDocument.find(id)
-           data_row = []
-           data_row += [s.id,s.identifier] # add druid and source id
-           header_row.each do |column|  # go throught the rest of the columns
-             value = s[revs_field_mappings[column][:field]]
-             if revs_field_mappings[column][:multi_valued] == true && !value.blank?
-               data_row << value.map {|val| val.to_s.gsub('"',"'")}.join(";")
-             elsif column == 'full_date' # format full date to contentDM standard, assuming it is a standard format
-               data_row << (s.revs_is_valid_datestring?(s.full_date) && !s.full_date.blank? ? Chronic.parse(s.full_date).to_date.strftime('%m/%d/%Y') : nil)
-             else 
-               data_row << (value.blank? ? nil : value.to_s.gsub('"',"'")) # replace double quotes with single quotes, as suggested by contenDM import  
-             end
-           end
-           data_row += ["#{s['image_id_ssm'].first}.tif"] # add filename (it is a multi_valued field, but revs image always only have a single image)
-           csv << data_row
-         rescue => e
-           puts " *** ERROR #{e.message}: #{id}"
-           num_errors+=1
-         end
+      if n % max_rows == 1 # the start of a new file
+        file_number += 1
+        output_file = "#{base_output_file}_#{file_number}.txt"      
+        csv = CSV.open(output_file, "wb", {:col_sep => "\t", encoding: 'iso-8859-1:UTF-8'}) 
+        puts "Writing file #{file_number} of #{number_of_files}: #{output_file}"
+        csv << ['druid','identifier'] + header_row + ['group_class','filename'] # add extra columns we need
       end
-
+      
+      id=doc['id']
+      puts "#{n} of #{total_docs}: #{id}"      
+      n+=1
+      begin
+         s=SolrDocument.find(id)
+         data_row = []
+         data_row += [s.id,s.identifier] # add druid and source id
+         header_row.each do |column|  # go throught the rest of the columns
+           value = s[revs_field_mappings[column][:field]]
+           if column == 'full_date' # format full date to contentDM standard, assuming it is a standard format
+             data_row << (s.revs_is_valid_datestring?(s.full_date) && !s.full_date.blank? ? Chronic.parse(s.full_date).to_date.strftime('%m/%d/%Y') : nil)
+           elsif revs_field_mappings[column][:multi_valued] == true && !value.blank? # multi_valued field
+             data_row << value.map {|val| cleanup_export_value(val,delimiter,delimiter_replace)}.join(delimiter)
+           else # any other non-multivalued or special field
+             data_row << cleanup_export_value(value,delimiter,delimiter_replace) 
+           end
+         end
+         data_row += [[s.group_class,s.car_group,s.car_class].flatten.join(', ')] # recombined separate group and class fields and combine with group_class field and make single valued again
+         data_row += ["#{s['image_id_ssm'].first}.tif"] # add filename (it is a multi_valued field, but revs image always only have a single image)
+         csv << data_row
+      rescue => e
+         puts " *** ERROR #{e.message}: #{id}"
+         num_errors+=1
+      end
     end
-    
+
     end_time=Time.now
 
     puts ""
-    puts "Finished at #{Time.now}, run lasted #{((end_time-start_time)/60).round} minutes, #{total_docs} exported, #{num_errors} errors"
-    puts " output to #{output_file}"
+    puts "Finished at #{Time.now}, total files: #{number_of_files}, run lasted #{((end_time-start_time)/60).round} minutes, #{total_docs} exported, #{num_errors} errors"
+    puts " base output file to #{base_output_file}"
     puts ""
 
   end

--- a/lib/tasks/bulk_export.rake
+++ b/lib/tasks/bulk_export.rake
@@ -1,0 +1,83 @@
+# encoding: UTF-8
+
+require 'jettywrapper' unless (Rails.env.production? || Rails.env.staging?)
+require 'rest_client'
+require 'csv'
+require 'countries'
+require 'pathname'
+require 'revs-utils'
+require 'nokogiri'
+$stdout.sync = true
+
+namespace :revs do
+  desc "Export all metadata for a given collection to CSV - used to facilitate transfer of revs content"
+  #Run Me: RAILS_ENV=production bundle exec rake revs:export_metadata_to_csv collection="John Dugdale Collection" # must be limited to a collection
+  #Run Me: RAILS_ENV=production bundle exec rake revs:export_metadata_to_csv collection="John Dugdale Collection" limit=100 # optionally sets a limit of number of items
+  #Run Me: RAILS_ENV=production nohup bundle exec rake revs:export_metadata_to_csv collection="John Dugdale Collection" > export.log 2>&1& # nohup mode with logged output
+
+  task :export_metadata_to_csv  => :environment do |t, args|
+
+    limit = ENV['limit'] || '' # if passed, limits to this many items only
+    collection = ENV['collection'] || '' # if passed, limits to this collection only
+    raise "you must provide a collection" if collection.blank?
+    
+    q="*:*"
+    q+=" AND collection_ssim:\"#{collection}\"" 
+
+    rows = limit.blank? ? "1000000" : limit
+
+    @all_docs = Blacklight.default_index.connection.select(:params => {:q => q, :fl=>'id', :rows=>rows})
+    total_docs=@all_docs['response']['docs'].size
+
+    start_time=Time.now
+    n=0
+    num_errors=0
+    output_file = "log/#{collection.gsub(" ","_")}_#{Time.now.strftime('%Y-%m-%dT%H:%M:%S.%LZ')}.txt"
+
+    puts ""
+    puts "Started at #{start_time}, #{total_docs} docs returned"
+    puts " limited to collection: #{collection}" 
+    puts " limited to #{limit} items" unless limit.blank?
+    puts " found #{total_docs} items"
+
+    puts ""
+    puts q
+    puts ""
+
+    CSV.open(output_file, "wb", {:col_sep => "\t"}) do |csv|
+
+      csv << SolrDocument.new.revs_field_mappings.map { |field, config| field.to_s } # write out all fields to the header
+      
+      @all_docs['response']['docs'].each do |doc|
+
+        id=doc['id']
+        n+=1
+        puts "#{n} of #{total_docs}: #{id}"
+         begin
+           s=SolrDocument.find(id)
+           data_row = []
+           s.revs_field_mappings.each do |field, config| 
+             if config[:multi_valued] == true && !s[config[:field]].blank?
+               data_row << s[config[:field]].join(";")
+             else
+               data_row << s[config[:field]] 
+             end
+           end
+           csv << data_row
+         rescue => e
+           puts " *** ERROR #{e.message}: #{id}"
+           num_errors+=1
+         end
+      end
+
+    end
+    
+    end_time=Time.now
+
+    puts ""
+    puts "Finished at #{Time.now}, run lasted #{((end_time-start_time)/60).round} minutes, #{total_docs} exported, #{num_errors} errors"
+    puts " output to #{output_file}"
+    puts ""
+
+  end
+end

--- a/lib/tasks/bulk_export.rake
+++ b/lib/tasks/bulk_export.rake
@@ -10,7 +10,8 @@ require 'nokogiri'
 $stdout.sync = true
 
 namespace :revs do
-  desc "Export all metadata for a given collection to CSV - used to facilitate transfer of revs content"
+  desc "Export all metadata for a given collection to CSV - used to facilitate transfer of revs content to contentDM"
+  # https://www.oclc.org/support/services/contentdm/help/project-client-help/entering-metadata/using-tab-delimited-text-files.en.html
   #Run Me: RAILS_ENV=production bundle exec rake revs:export_metadata_to_csv collection="John Dugdale Collection" # must be limited to a collection
   #Run Me: RAILS_ENV=production bundle exec rake revs:export_metadata_to_csv collection="John Dugdale Collection" limit=100 # optionally sets a limit of number of items
   #Run Me: RAILS_ENV=production nohup bundle exec rake revs:export_metadata_to_csv collection="John Dugdale Collection" > export.log 2>&1& # nohup mode with logged output
@@ -46,8 +47,13 @@ namespace :revs do
 
     CSV.open(output_file, "wb", {:col_sep => "\t"}) do |csv|
 
-      csv << SolrDocument.new.revs_field_mappings.map { |field, config| field.to_s } # write out all fields to the header
-      
+      revs_field_mappings = SolrDocument.new.revs_field_mappings.with_indifferent_access
+      excluded_fields = ['resaved_at','identifier','single_year','archive_name','collections','highlighted'] # exclude these
+
+      header_row = []
+      revs_field_mappings.each { |field, config| header_row << field.to_s unless excluded_fields.include? field.to_s } # write out all fields to the header
+      csv << ['druid','identifier'] + header_row + ['filename'] # add extra columns we need
+
       @all_docs['response']['docs'].each do |doc|
 
         id=doc['id']
@@ -56,13 +62,18 @@ namespace :revs do
          begin
            s=SolrDocument.find(id)
            data_row = []
-           s.revs_field_mappings.each do |field, config| 
-             if config[:multi_valued] == true && !s[config[:field]].blank?
-               data_row << s[config[:field]].join(";")
-             else
-               data_row << s[config[:field]] 
+           data_row += [s.id,s.identifier] # add druid and source id
+           header_row.each do |column|  # go throught the rest of the columns
+             value = s[revs_field_mappings[column][:field]]
+             if revs_field_mappings[column][:multi_valued] == true && !value.blank?
+               data_row << value.map {|val| val.to_s.gsub('"',"'")}.join(";")
+             elsif column == 'full_date' # format full date to contentDM standard, assuming it is a standard format
+               data_row << (s.revs_is_valid_datestring?(s.full_date) && !s.full_date.blank? ? Chronic.parse(s.full_date).to_date.strftime('%m/%d/%Y') : nil)
+             else 
+               data_row << (value.blank? ? nil : value.to_s.gsub('"',"'")) # replace double quotes with single quotes, as suggested by contenDM import  
              end
            end
+           data_row += ["#{s['image_id_ssm'].first}.tif"] # add filename (it is a multi_valued field, but revs image always only have a single image)
            csv << data_row
          rescue => e
            puts " *** ERROR #{e.message}: #{id}"

--- a/lib/tasks/bulk_load.rake
+++ b/lib/tasks/bulk_load.rake
@@ -1215,7 +1215,7 @@ namespace :revs do
       flags.each do |flag|
         username = flag.user.blank? ? "anonymous" : flag.user.username
         user_role = flag.user.blank? ? "n/a" : flag.user.role
-        csv << [flag.id,flag.druid,flag.item.title,flag.solr_document['source_id_ssi'],flag.comment,username,user_role,flag.created_at,flag.state]
+        csv << [flag.id,flag.druid,flag.item.title,flag.source_id,flag.comment,username,user_role,flag.created_at,flag.state]
       end
     end
   end

--- a/lib/tasks/bulk_load.rake
+++ b/lib/tasks/bulk_load.rake
@@ -224,6 +224,72 @@ namespace :revs do
     end
 
   end
+  
+  desc "Add source id to various model records that have druids -- should only need to be run once"
+  #Run Me: RAILS_ENV=production nohup bundle exec rake revs:add_source_id &
+  task :add_source_id => :environment do |t, args|
+
+    puts "Started at #{Time.now}"
+    count_flag = success_flag = error_flag = 0
+    count_annotation = success_annotation = error_annotation = 0
+    count_saved_item = success_saved_item = error_saved_item = 0
+    count_item = success_item = error_item = 0
+      
+    puts "Updating flags..."
+    Flag.find_each do |flag|
+      count_flag += 1
+      begin
+        flag.update_attributes(:source_id => flag.solr_document['source_id_ssi'])
+        success_flag += 1
+      rescue => e
+        error_flag +=1
+        puts "*** ERROR ON flag #{flag.id} - #{e.message}"
+      end
+    end
+
+    puts "Updating annotations..."
+    Annotation.find_each do |annotation|
+      count_annotation += 1
+      begin
+        annotation.update_attributes(:source_id => annotation.solr_document['source_id_ssi'])
+        success_annotation += 1
+      rescue => e
+        error_annotation +=1
+        puts "*** ERROR ON annotation #{annotation.id} - #{e.message}"
+      end
+    end
+
+    puts "Updating saved_items..."
+    SavedItem.find_each do |saved_item|
+      count_saved_item += 1
+      begin
+        saved_item.update_attributes(:source_id => saved_item.solr_document['source_id_ssi'])
+        success_saved_item += 1
+      rescue => e
+        error_saved_item +=1
+        puts "*** ERROR ON saved_item #{saved_item.id} - #{e.message}"
+      end
+    end    
+
+    puts "Updating items..."
+    Item.find_each do |item|
+      count_item += 1
+      begin
+        item.update_attributes(:source_id => item.solr_document['source_id_ssi'])
+        success_item += 1
+      rescue => e
+        error_item +=1
+        puts "*** ERROR ON item #{item.id} - #{e.message}"
+      end
+    end 
+    
+    puts "Successful flags: #{success_flag}.  Errored flags: #{error_flag}.  Total flags: #{count_flag}."
+    puts "Successful annotations: #{success_annotation}.  Errored annotations: #{error_annotation}.  Total annotations: #{count_annotation}."
+    puts "Successful saved items: #{success_saved_item}.  Errored saved items: #{error_saved_item}.  Total saved items: #{count_saved_item}."
+    puts "Successful items: #{success_item}.  Errored items: #{error_item}.  Total items: #{count_item}."
+    puts "Ended at #{Time.now}"
+    
+  end
 
   desc "Batch update a single specified field with a single specified value based on results from a supplied query -- if the field to update is multivalued, you MUST also provide an old value to search for to avoid replacing the entire field"
   #Run Me: RAILS_ENV=production rake revs:bulk_update_field solr_query='photographer_ssi:"Rudolfo Mailander"' field_to_update="photographer" new_value="Rodolfo Mailander" collection="John Dugdale Collection" # limited to a collection

--- a/lib/tasks/bulk_load.rake
+++ b/lib/tasks/bulk_load.rake
@@ -1034,8 +1034,8 @@ namespace :revs do
 
   desc "Bulk hide or show images from a given collection"
   task :change_visibility_collection, [:collection_name, :visibility_value, :update_timestamp] => :environment do |t, args|
-    # call with RAILS_ENV=production rake revs:change_visibility_collection["Albert R. Bochroch Photographic Archive",1,true] to show all images in the collection and update the timestamp; note the collection itself is unaffected
-    # call with RAILS_ENV=production rake revs:change_visibility_collection["Albert R. Bochroch Photographic Archive",0,false] to hide all images in the collection and do not update the timestamp; note the collection itself is unaffected
+    # call with RAILS_ENV=production rake revs:change_visibility_collection["Albert R. Bochroch Photographic Archive",1,true] to show all images in the collection and update the timestamp (including the collection itself)
+    # call with RAILS_ENV=production rake revs:change_visibility_collection["Albert R. Bochroch Photographic Archive",0,false] to hide all images in the collection and do not update the timestamp  (including the collection itself)
 
     Revs::Application.config.use_editstore = false
 


### PR DESCRIPTION
also keep it up to date when saving rows

need to run rake revs:add_source_id after deploy