### PR TITLE
also disallow flagging when editing is disabled -- update message

### DIFF
--- a/app/views/catalog/_show_collection_member.html.erb
+++ b/app/views/catalog/_show_collection_member.html.erb
@@ -144,7 +144,12 @@
             "#{Revs::Application.config.purl}/#{@document[:id]}",:target=>"_new", :class => "purl") %>
           </li>
 
-          <% if (can?(:read, Flag) || can?(:add_new_flag_to, @document)) %>
+         <% if Revs::Application.config.disable_editing %>
+                <li>
+                  <%=t('revs.messages.no_editing_allowed')%>
+                </li>
+          <% end %>
+          <% if (can?(:read, Flag) || can?(:add_new_flag_to, @document)) && !Revs::Application.config.disable_editing%>
               <li>
 
                 <div id="flags_link">
@@ -199,7 +204,7 @@
                 <% end # end check for a logged in user having resolved flags %>
             <% end # end check for user has ability to add flags%>
 
-              <% if !user_signed_in? && can?(:add_new_flag_to, @document) %>
+              <% if !user_signed_in? && can?(:add_new_flag_to, @document) && !Revs::Application.config.disable_editing %>
               <li>
                 <span id="feedback_link">
                   <%= t('revs.nav.content_corrections', :create_an_account_link => link_to(t('revs.nav.create_an_account'), new_user_session_path), :feedback_link => link_to(t('revs.nav.feedback'), contact_us_path(:from => request.path, :subject => 'metadata', :message => "Correction to \"#{@document.title}\" (identifier: #{@document.identifier})"))).html_safe %>
@@ -213,11 +218,6 @@
         <% if can? :curate, :all %>
           <ul class="nav list-unstyled item-actions curator-actions showOnLoad hidden-offscreen">
             <li class="nav-header"><%= t('revs.curator.curator_actions') %></li>
-          <% if Revs::Application.config.disable_editing %>
-            <li>
-              <%=t('revs.messages.no_editing_allowed')%>
-            </li>
-          <% end %>
             <% if can?(:update_metadata, :all) && !Revs::Application.config.disable_editing
                 edit_mode_link_text = in_curator_edit_mode ? t('revs.curator.leave_edit_mode') : t('revs.curator.enter_edit_mode')
                 %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -110,7 +110,7 @@ module Revs
 
     config.collier_archive_name = 'Revs Institute® Archives' # this is the name of the collier archive, it will be added to records if it does not yet exist when saving for remediating records that existed before we had multiple archives
 
-    config.disable_editing = false # if set to true, will disallow metadata editing, changing visibility and placeholder, and the creation of annotations - the things that can update a solr document
+    config.disable_editing = false # if set to true, will disallow metadata editing, changing visibility and placeholder, the creation of annotations and flags - the things that can update a solr document or add to the metadata editing load
     config.num_latest_user_activity = 3 # the latest number of flags/annotations to show on the user profile page
     config.num_flags_per_item_per_user = 5 # the number of times each user is allowed to flag a particular item
     #config.flag_sort_display = {FLAG_STATES[:open]=> I18n.t('revs.flags.open_state_display_name'),FLAG_STATES[:fixed]=> I18n.t('revs.flags.fixed_state_display_name'),FLAG_STATES[:wont_fix]=> I18n.t('revs.flags.wont_fix_state_display_name')}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,8 +82,8 @@ en:
       status: "Status"
       showing: "Showing"
       unencoded: "Unencoded"
-      no_editing_allowed: "IMPORTANT NOTE: the website is currently undergoing mainteance and no editing is allowed at this time."
-      search_affected: "IMPORTANT NOTE: the website is currently undergoing maintenace and text searches may not produce the expected results or may be missing results until completed."
+      no_editing_allowed: "IMPORTANT NOTE: We apologize, but the website is not able to accept suggestions, annotations or updates to metadata until further notice."
+      search_affected: "IMPORTANT NOTE: the website is currently undergoing maintenance and text searches may not produce the expected results or may be missing results until completed."
       reorder: "Drag and drop to reorder"
       changes_not_saved: "Please note, in %{rails_env} your metadata changes will NOT be permanently saved."
       not_authorized: 'You are not authorized to perform this action.'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160928213450) do
+ActiveRecord::Schema.define(version: 20170601224210) do
 
   create_table "annotations", force: :cascade do |t|
     t.integer  "user_id"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20160928213450) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.integer  "image_number", default: 0
+    t.string   "source_id"
   end
 
   add_index "annotations", ["druid"], name: "index_annotations_on_druid"
@@ -64,6 +65,7 @@ ActiveRecord::Schema.define(version: 20160928213450) do
     t.string   "state",              default: "open"
     t.string   "notification_state"
     t.text     "private_comment"
+    t.string   "source_id"
   end
 
   add_index "flags", ["druid"], name: "index_flags_on_druid"
@@ -100,6 +102,7 @@ ActiveRecord::Schema.define(version: 20160928213450) do
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
     t.string   "title",            limit: 400
+    t.string   "source_id"
   end
 
   add_index "items", ["druid"], name: "index_items_on_druid", unique: true
@@ -121,6 +124,7 @@ ActiveRecord::Schema.define(version: 20160928213450) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.integer  "position"
+    t.string   "source_id"
   end
 
   add_index "saved_items", ["druid"], name: "index_saved_items_on_druid"


### PR DESCRIPTION
At some point we will need to disallow any form of metadata editing before we bulk export all metadata.  This blocks flagging as well so people will no longer make suggestions (that can't be acted upon).