### PR TITLE
block malicious user registrations

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,11 +2,11 @@ class Admin::UsersController < AdminController
 
   def index
     get_paging_params
-    @role = params[:role] || 'curator'
+    @status = params[:status] || 'true'
     @filter = filter_field(params[:filter])
     @filter_role = params[:filter_role] || "all"
     @filter_visibility = filter_field(params[:filter_visibility])
-
+    @filter_status = params[:filter_status] || "all"
     @users = User.all
 
     if !@search.blank?
@@ -27,6 +27,14 @@ class Admin::UsersController < AdminController
       @users=@users.where(:public => true)
     elsif @filter_visibility == 'private'
       @users=@users.where(:public => false)
+    end
+
+    if @filter_status == 'active'
+      @users=@users.where(:active => true)
+    elsif @filter_status == 'inactive'
+      @users=@users.where(:active => false)
+    elsif @filter_status == 'inactive_new'
+      @users=@users.where(:active => false, :login_count => 0)
     end
 
     @users=@users.order(@order).page(@current_page).per(@per_page)
@@ -56,21 +64,21 @@ class Admin::UsersController < AdminController
     end
   end
 
-  def bulk_update_role
+  def bulk_update_status
     get_paging_params
-    @role=params[:role]
+    @status=params[:status]
     @selected_users=params[:selected_users]
     if @selected_users
       @selected_users.each do |user_id|
           user=User.find(user_id)
-          user.role=@role
+          user.active=@status
           user.save
        end
-      flash[:success]=t('revs.admin.user_roles_updated',:num=>@selected_users.size,:role=>@role)
+      flash[:success]=t('revs.admin.user_status_updated',:num=>@selected_users.size,:status=>@status)
     else
-      flash[:error]=t('revs.admin.no_user_roles_updated')
+      flash[:error]=t('revs.admin.no_users_updated')
     end
-    redirect_to admin_users_path(paging_params({:email=>params[:email],:role=>@role}))
+    redirect_to admin_users_path(paging_params({:email=>params[:email],:status=>@status}))
   end
 
   def destroy

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -264,6 +264,7 @@ class ApplicationController < ActionController::Base
       'sunet' => 'sunet ASC',
       'role' => 'role ASC',
       'state' => 'state ASC',
+      'active' => 'active ASC',
       'login_count_desc' => 'login_count DESC',
       'created_at_desc' => 'created_at DESC',
       'updated_at_desc' => 'updated_at DESC',

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -16,22 +16,21 @@ class RegistrationsController < Devise::RegistrationsController
   def create
     @spammer=params[:email_confirm] # if this hidden field is filled in, its a spam bot
     @loadtime=params[:loadtime] # this is the time the page was rendered, if it is submitted too fast, its a spammer
-    if is_spammer?(3) && Revs::Application.config.spam_reg_checks
-
-      flash[:notice]=t("revs.about.contact_message_spambot") # show a friendly but different message to suspected spambots
-      # spammers begone to the home page to make it harder to submit the form again
+    @username=params[:user][:username]
+    @email=params[:user][:email]
+    if Revs::Application.config.spam_reg_checks && (is_spammer?(3) || spam_registration?(@username))
+      flash[:notice]=t("revs.user.spam_registration")
       redirect_to root_path
 
-    elsif params[:user][:email].include?("@stanford.edu") || params[:user][:username].include?("@stanford.edu") # anyone who tries to register with a stanford email address or username will get an error
+    elsif @email.include?("@stanford.edu") || @username.include?("@stanford.edu") # anyone who tries to register with a stanford email address or username will get an error
       redirect_to :root, :alert=>t('revs.authentication.stanford_create_warning')
       return false
 
     else
-      @username=params[:user][:username]
-      @email=params[:user][:email]
       super
+      
     end
-    
+
   end
 
   # override devise update profile page so that user is not required to enter the current password
@@ -115,5 +114,9 @@ class RegistrationsController < Devise::RegistrationsController
                   :avatar, :avatar_cache, :remove_avatar, :login_count, :favorites_public,
                   :registration_answer, :registration_question_number)
   end
-        
+
+  def spam_registration?(username)
+    (username =~ /\D\d\D{5}\d{3}/) == 0 # exact match for this pattern of username is a spam registrant, e.g. 'm9tlbdv809'
+  end
+
 end

--- a/app/mailers/revs_mailer.rb
+++ b/app/mailers/revs_mailer.rb
@@ -18,6 +18,12 @@ class RevsMailer < ActionMailer::Base
     mail(:to=>to, :cc=>cc, :subject=>"Contact Message from Revs Digital Library - #{@subject}") unless to.nil? || !valid_email?(to) # only send an email if we have a valid to address (if user has tampered with subject params, this might not be the case)
   end
 
+  def new_users_notification(opts={})
+    @num_users=opts[:num_users]
+    to=Revs::Application.config.new_registration_notification
+    mail(:to=>to,:subject=>I18n.t('revs.contact.notification_new_users')) if valid_email?(to)
+  end
+  
   def auto_response(opts={})
     @email=opts[:email]
     @subject=opts[:subject]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ActiveRecord::Base
          :lockable, :timeoutable, :omniauthable
 
   # Setup accessible (or protected) attributes for your model
-  attr_accessor :subscribe_to_mailing_list, :subscribe_to_revs_mailing_list # not persisted, just used on the signup form
+  attr_accessor :subscribe_to_mailing_list, :subscribe_to_revs_mailing_list, :registration_question_number, :registration_answer # not persisted, just used on the signup form
   attr_accessor :login # virtual method that will refer to either email or username
 
   # all "regular" has_many associations are done via custom methods below so we can add visibility filtering for items
@@ -42,6 +42,7 @@ class User < ActiveRecord::Base
   after_save :create_default_favorites_list # create the default favorites list if it doesn't exist when a user logs in
 
   validate :check_role_name
+  validate :registration_answer_correct, :on => :create, :if=>lambda{Revs::Application.config.spam_reg_checks == true}
   validates :username, :uniqueness => { :case_sensitive => false }
   validates :username, :length => { :in => 5..50}
   validates :username, :format => { :with => /\A\D.+/,:message => "must start with a letter" }
@@ -227,6 +228,10 @@ class User < ActiveRecord::Base
 
   def check_role_name
     errors.add(:role, :not_valid) unless ROLES.include? role.to_s
+  end
+
+  def registration_answer_correct
+    errors.add(:registration_answer, :not_correct) unless !registration_answer.blank? && (registration_answer.strip.downcase == Revs::Application.config.reg_questions[registration_question_number.to_i][:answer].downcase)
   end
 
   def no_name_entered?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ActiveRecord::Base
   after_save :create_default_favorites_list # create the default favorites list if it doesn't exist when a user logs in
 
   validate :check_role_name
-  validate :registration_answer_correct, :on => :create, :if=>lambda{Revs::Application.config.spam_reg_checks == true}
+  validate :registration_answer_correct, :on => :create, :if=>lambda{Revs::Application.config.spam_reg_checks == true && !Revs::Application.config.reg_questions.blank?}
   validates :username, :uniqueness => { :case_sensitive => false }
   validates :username, :length => { :in => 5..50}
   validates :username, :format => { :with => /\A\D.+/,:message => "must start with a letter" }

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -54,6 +54,15 @@
         </div>
       </div>
 
+      <div class="form-group">
+        <label for="filter_status" class="control-label col-sm-4 col-lg-3">
+          <%= t('revs.admin.filter_status') %>
+        </label>
+        <div class="col-xs-4 col-md-2">
+          <%= select_tag 'filter_status', options_for_select({'all'=>'all','Active only'=>'active','Inactive only'=>'inactive','Inactive new users'=>'inactive_new'}, @filter_status), class:"form-control" %>
+        </div>
+      </div>
+
       <%= render :partial=>'shared/per_page_dropdown' %>
 
       <div class="form-group">
@@ -65,7 +74,7 @@
   <% end %>
 
   <% if @users.size > 0 %>
-    <%= form_tag(bulk_update_role_admin_users_path, method: 'post', class:'form-inline update-users') do %>
+    <%= form_tag(bulk_update_status_admin_users_path, method: 'post', class:'form-inline update-users') do %>
     <fieldset>
       <legend><%= t('revs.admin.update_users')%></legend>
 
@@ -73,7 +82,7 @@
           <label for="role">
             <%=t('revs.admin.set_checked_users')%>
           </label>
-            <%= select_tag 'role', options_for_select(User.roles,@role), class:"form-control input-sm" %>
+            <%= select_tag 'status', options_for_select({'Active'=>'true','Inactive'=>'false'} , @status), class:"form-control input-sm" %>
             <!--<input type="checkbox" name="select-all" id="admin-select-all-users"> --> <%#=t('revs.nav.select_all')%>
         </div>
         <%= submit_tag t('revs.nav.submit'), :class => 'btn btn-default btn-sm' %>
@@ -110,6 +119,10 @@
           <%= link_to t('revs.admin.role'),
                 admin_users_path(:order=>'role', :search=>@search, :filter=>@filter, :per_page=>@per_page) %>
         </th>
+        <th>
+          <%= link_to t('revs.admin.active'),
+                admin_users_path(:order=>'active', :search=>@search, :filter=>@filter, :per_page=>@per_page) %>
+        </th>
         <th class="right">
           <%= link_to t('revs.admin.login_count'),
                 admin_users_path(:order=>'login_count_desc', :search=>@search, :filter=>@filter, :per_page=>@per_page) %>
@@ -134,12 +147,13 @@
          <td><%= user.full_name %></td>
          <td class="centered"><%= user.sunet_user? ? t('revs.messages.switch_yes') : t('revs.messages.switch_no') %></td>
          <td><%= user.role %></td>
+         <td><%= user.active %></td>
          <td class="right"><%= user.login_count %></td>
          <td><%= show_as_date(user.created_at.in_time_zone) %></td>
          <td class="centered"><%= user.confirmed_at.blank? ? t('revs.messages.switch_no') : t('revs.messages.switch_yes') %></td>
          <td class="centered">
-           <%= link_to "#{t('revs.actions.edit')}", edit_admin_user_path(user.id),:id=>"edit-#{user.id}" %>
-           <%= link_to "#{t('revs.user.view_profile')}", user_path(user), :class => "admin-action-link" %>
+           <%= link_to "#{t('revs.actions.edit')}", edit_admin_user_path(user.id),:id=>"edit-#{user.id}" %> |
+           <%= link_to "#{t('revs.user.profile')}", user_path(user), :class => "admin-action-link" %>
          </td>
        </tr>
       <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,7 +14,7 @@
     <%= hidden_field_tag 'loadtime',Time.now%>
 
     <div class="form-group hidden">
-  	  <label class="control-label col-xs-12 col-sm-4 col-md-3" for="email"><%=t('revs.contact.spambot_label')%></label>
+  	  <label class="control-label col-xs-12 col-sm-4 col-md-3" for="email_confirm"><%=t('revs.contact.spambot_label')%></label>
   	  <div class="col-xs-8 col-sm-6 col-md-5">
   	    <%=text_field_tag 'email_confirm', "", :placeholder => t('revs.contact.spambot'), :class => "form-control", :autocomplete => 'off' %>
   	  </div>
@@ -66,6 +66,17 @@
             :placeholder => t('revs.user.confirm_password'), :class => "form-control" %>
       </div>
     </div>
+
+    <% unless Revs::Application.config.reg_questions.blank? %>
+    <% question_number = rand(Revs::Application.config.reg_questions.size) %>
+    <%= hidden_field_tag 'user[registration_question_number]',question_number%>
+      <div class="form-group">
+        <label class="control-label col-xs-12 col-sm-4 col-md-3" for="user_registration_answer"><%= Revs::Application.config.reg_questions[question_number][:question] %></label>
+        <div class="col-xs-8 col-sm-6 col-md-5">
+          <%=text_field_tag 'user[registration_answer]', "", :placeholder => t('revs.authentication.registration_question'), :class => "form-control", :autocomplete => 'off' %>
+        </div>
+      </div>
+    <% end %>
 
     <div class="form-group">
       <div class="col-sm-offset-4 col-sm-9 col-md-offset-3">

--- a/app/views/revs_mailer/new_users_notification.erb
+++ b/app/views/revs_mailer/new_users_notification.erb
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+<p><%=@num_users%> users have registered on the Revs Digital Library and require activation.</p>
+</body></html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -123,6 +123,13 @@ module Revs
 #    config.site_message="The website will be down for scheduled maintenance today, July 8, at 3pm Pacific Time for approximately 30 minutes." # set to some string to show a message on the top of each message (like to advertise a known site outage) , leave blank for no message
 
     config.site_message = ""
+    # if the following configuration is not nil or a blank array, one of these questions will be asked at random when user's register to try and block spammy registrations
+    # format is an array of hashes, the answer is not case sensitive
+    config.reg_questions = [
+      {:question=>'What is the name of the car company that manufacturers the Mustang?',:answer=>'Ford'},
+      {:question=>'What is the first name of the founder of Ferrari?',:answer=>'Enzo'}
+    ]
+    config.spam_reg_checks = true # set to false to skip spam registration checks (useful in testing)
 
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -126,10 +126,10 @@ module Revs
     config.site_message = ""
     # if the following configuration is not nil or a blank array, one of these questions will be asked at random when user's register to try and block spammy registrations
     # format is an array of hashes, the answer is not case sensitive
-    config.reg_questions = [
-      {:question=>'What is the name of the car company that manufacturers the Mustang?',:answer=>'Ford'},
-      {:question=>'What is the first name of the founder of Ferrari?',:answer=>'Enzo'}
-    ]
+    config.reg_questions = []
+    #   {:question=>'What is the name of the car company that manufacturers the Mustang?',:answer=>'Ford'},
+    #   {:question=>'What is the first name of the founder of Ferrari?',:answer=>'Enzo'}
+    # ]
     config.require_manual_account_activation = true # set to true to require an admin to manually activate any new account registrations
     config.new_registration_notification = 'petucket@stanford.edu' # email address to receive daily notifications of new registrations
     config.spam_reg_checks = true # set to false to skip spam registration checks (useful in testing)

--- a/config/application.rb
+++ b/config/application.rb
@@ -85,7 +85,8 @@ module Revs
     config.contact_us_topics = {'default'=>'revs.contact.select_topic', 'metadata'=>'revs.contact.metadata_issue','terms of use'=>'revs.contact.terms_of_use', 'special collections'=>'revs.contact.special_collections','error'=>'revs.contact.problem','other'=>'revs.contact.other_questions'} # sets the list of topics shown in the contact us page
     config.contact_us_recipients = {'default'=>'digcoll@jirasul.stanford.edu', 'terms of use'=>'library@revsinstitute.org','metadata'=>'digcoll@jirasul.stanford.edu','error'=>'digcoll@jirasul.stanford.edu','other'=>'digcoll@jirasul.stanford.edu','special collections'=>'specialcollections@stanford.edu'} # sets the email address for each contact us topic configed aboveend
     config.contact_us_cc_recipients = {'default'=>'revs-other@jirasul.stanford.edu', 'metadata'=>'revs-metadata-comment@jirasul.stanford.edu', 'error'=>'revs-problems@jirasul.stanford.edu','other'=>'revs-other@jirasul.stanford.edu'} # sets the CC email address for each contact us topic configed above
-
+    config.new_registration_notification = 'petucket@stanford.edu'
+    
     # these collections are only available for non-commerical reproduction and will show a special statement instead of the use and reproduction statement in the item itself
     config.collections_available_for_noncommerical_reproduction =
       [ 'jh550nq3200', # Worner
@@ -129,6 +130,8 @@ module Revs
       {:question=>'What is the name of the car company that manufacturers the Mustang?',:answer=>'Ford'},
       {:question=>'What is the first name of the founder of Ferrari?',:answer=>'Enzo'}
     ]
+    config.require_manual_account_activation = true # set to true to require an admin to manually activate any new account registrations
+    config.new_registration_notification = 'petucket@stanford.edu' # email address to receive daily notifications of new registrations
     config.spam_reg_checks = true # set to false to skip spam registration checks (useful in testing)
 
   end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,7 +3,7 @@
 en:
   devise:
     confirmations:
-      confirmed: "Your account was successfully confirmed. You are now signed in."
+      confirmed: "Your account was successfully confirmed. You may now log in."
       send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes."
     failure:

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,7 +3,7 @@
 en:
   devise:
     confirmations:
-      confirmed: "Your account was successfully confirmed. You may now log in."
+      confirmed: "Your email address was successfully confirmed."
       send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes."
     failure:
@@ -16,7 +16,7 @@ en:
       timeout: "Your session expired, please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your account before continuing."
-      account_has_been_deactivated: "Your account has been deactivated by an administrator.  Please contact us if you believe this is an error."
+      account_has_been_deactivated: "It appears you may have just signed up and your account has not yet been activated by an administrator.  This may take a couple of days - please try again later.  If you have previously logged in, your account has been deactivated by an administrator."
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"
@@ -41,6 +41,8 @@ en:
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please open the link to activate your account."
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and click on the confirm link to finalize confirming your new email address."
       updated: "You updated your account successfully."
+      user:
+        signed_up_but_account_has_been_deactivated: "A message with a confirmation link has been sent to your email address. Please open the link to activate your account.  Your account also needs to be manually confirmed by an administrator."
     sessions:
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -566,6 +566,7 @@ en:
       label_metadata_sources: "Metadata Sources"
       label_more_metadata: "Has more metadata"
     user:
+      spam_registration: 'Your IP address has been reported as a suspected malicious registration and your account has been deleted.'
       stanford_warning_html: '<strong>Important:</strong> Stanford users should not create a new account or enter their SUNET ID or passwords on this website.  %{webauth_link}'
       stanford_email_sunet_warning_html: ' <strong>Note</strong>.  You have not changed your default username, which is your Stanford SUNET ID.'
       stanford_email_sunet_warning2_html: 'Since your username may appear on the website, you may want to <a href="/users/edit">change this</a> to avoid other users guessing your email address easily.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,10 @@ en:
               cannot_be_more_than_one_favorites_list_per_user: 'there cannot be more than one favorites list per user'
             visibility:
               must_be_selected: 'must be selected.'
+        user:
+          attributes:
+            registration_answer:
+              not_correct: 'is not correct.  Please answer the question to register -- this is used to reduce spurious user registrations.'
         saved_item:
           attributes:
             druid:
@@ -242,6 +246,7 @@ en:
       stanford_email_warning1: "Your username cannot be a Stanford email address other than your own."
       stanford_email_warning2: "Your username cannot be a Stanford email address."
       stanford_user: "Stanford user"
+      registration_question: "Please answer the question to register."
       profile_page_is: "Profile page is"
       users_username_public: "The user's username is publicly visible on the Revs site"
       users_if_profile_public: "If the user's profile page is public, the user's first and last name entered below (instead of username) is used to identify the user on the site."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,6 +225,7 @@ en:
       image_uncertain: "Due to copyright restrictions, this item may not be available for commercial use. To request this image, please contact "
       describe_problem: 'Please describe your question or problem.'
       thanks: 'Thanks for contacting the Revs Digital Library'
+      notification_new_users: 'New users have registered on the website.'
     authentication:
       new_user: 'New user?'
       sign_in: 'Sign in'
@@ -295,19 +296,21 @@ en:
       name: "Name"
       stanford: "Stanford?"
       role: "Role"
+      active: "Active"
       per_page: "Per page"
       login_count: "Logins"
       filter_role: "By role"
       filter_type: "By type"
+      filter_status: "By status"
       filter_visibility: "By visibility"
       registered_on: "Registered"
       confirmed: "Confirmed?"
       no_users_found: "No users were found with your search criteria."
       none_found: "None found"
       feature_on_home_page: "Feature"
-      user_roles_updated: "Successfully updated %{num} users to the role '%{role}'"
-      no_user_roles_updated: "You did not select any users to update"
-      set_checked_users: "Update selected to role"
+      user_status_updated: "Successfully updated %{num} users to the account status '%{status}'"
+      no_users_updated: "You did not select any users to update"
+      set_checked_users: "Update selected to account status"
       last_sign_in: 'Last sign in'
       num_logins: 'Number of logins'
       sidebar:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,7 @@ Revs::Application.routes.draw do
   namespace :admin do
     resources :users do
       collection do
-        post 'bulk_update_role', :to => 'users#bulk_update_role'
+        post 'bulk_update_status', :to => 'users#bulk_update_status'
       end
     end
     resources :saved_queries do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,6 +6,10 @@ if ['production','staging'].include? @environment
     rake "blacklight:delete_old_searches[5]"
   end
 
+  every 1.days, :at => '1:00 am' do
+    rake "revs:notify_new_registrations"
+  end
+
 end
 
 if ['production'].include? @environment

--- a/spec/features/user_reg_spec.rb
+++ b/spec/features/user_reg_spec.rb
@@ -2,81 +2,59 @@ require "rails_helper"
 
 describe("User Registration",:type=>:request,:integration=>true) do
   
-  before :each do
-    @password='password'
-    RevsMailer.stub_chain(:mailing_list_signup,:deliver).and_return('a mailer')
-    RevsMailer.stub_chain(:revs_institute_mailing_list_signup,:deliver).and_return('a mailer')
-  end
+  context 'regular registration' do
   
-  it "should register a new user with the default role and defaulting to public profile as hidden" do
+    before :each do
+      @password='password'
+      Revs::Application.config.spam_reg_checks = false # disable spam checks for testing
+      RevsMailer.stub_chain(:mailing_list_signup,:deliver).and_return('a mailer')
+      RevsMailer.stub_chain(:revs_institute_mailing_list_signup,:deliver).and_return('a mailer')
+    end
 
-    expect(RevsMailer).not_to receive(:mailing_list_signup)
-    expect(RevsMailer).not_to receive(:revs_institute_mailing_list_signup)
+    it "should register a new user with the default role and defaulting to public profile as hidden" do
 
-    @username='testing'
-    @email="#{@username}@test.com"
-    # regsiter a new user
-    visit new_user_registration_path
-    fill_in 'register-email', :with=> @email
-    fill_in 'register-username', :with=> @username
-    fill_in 'user_password', :with=> @password
-    fill_in 'user_password_confirmation', :with=> @password
-    sleep 6.seconds
-    click_button 'Sign up'
-    
-    should_register_ok
-    
-    # check the database
-    user=User.last
-    expect(user.role).to eq('user')
-    expect(user.username).to eq(@username)
-    expect(user.email).to eq(@email)
-    expect(user.public).to eq(false)
-    
-    favorites=Gallery.last
-    expect(favorites.gallery_type).to eq('favorites')
-    expect(favorites.user_id).to eq(user.id)
-
-  end
-
-  it "should register a new user and send an email to join the Revs Program list if selected" do
-
-      expect(RevsMailer).to receive(:mailing_list_signup)
+      expect(RevsMailer).not_to receive(:mailing_list_signup)
       expect(RevsMailer).not_to receive(:revs_institute_mailing_list_signup)
-        
-      @username='testing2'
-      @email="#{@username}@test.com" 
+
+      @username='testing'
+      @email="#{@username}@test.com"
       # register a new user
-      register_new_user(@username,@password,@email)    
-      check 'user_subscribe_to_mailing_list'
-      sleep 6.seconds
+      visit new_user_registration_path
+      fill_in 'register-email', :with=> @email
+      fill_in 'register-username', :with=> @username
+      fill_in 'user_password', :with=> @password
+      fill_in 'user_password_confirmation', :with=> @password
       click_button 'Sign up'
 
       should_register_ok
-    
+
       # check the database
       user=User.last
       expect(user.role).to eq('user')
       expect(user.username).to eq(@username)
       expect(user.email).to eq(@email)
+      expect(user.public).to eq(false)
+
+      favorites=Gallery.last
+      expect(favorites.gallery_type).to eq('favorites')
+      expect(favorites.user_id).to eq(user.id)
 
     end
 
-    it "should register a new user and send an email to join the Revs Institute Mailing list if selected" do
+    it "should register a new user and send an email to join the Revs Program list if selected" do
 
-        expect(RevsMailer).to receive(:revs_institute_mailing_list_signup)
-        expect(RevsMailer).not_to receive(:mailing_list_signup)
+        expect(RevsMailer).to receive(:mailing_list_signup)
+        expect(RevsMailer).not_to receive(:revs_institute_mailing_list_signup)
 
-        @username='testing3'
+        @username='testing2'
         @email="#{@username}@test.com" 
         # register a new user
-        register_new_user(@username,@password,@email) 
-        check 'user_subscribe_to_revs_mailing_list'
-        sleep 6.seconds
+        register_new_user(@username,@password,@email)
+        check 'user_subscribe_to_mailing_list'
         click_button 'Sign up'
 
         should_register_ok
-       
+
         # check the database
         user=User.last
         expect(user.role).to eq('user')
@@ -84,114 +62,143 @@ describe("User Registration",:type=>:request,:integration=>true) do
         expect(user.email).to eq(@email)
 
       end
- 
-     it "should create a username as the sunetID when a new Stanford user signs in via webauth" do
-    
-      @username="somesunet"
 
-      expect(User.where(:username=>@username).size).to eq(0) # doesn't exist yet
+      it "should register a new user and send an email to join the Revs Institute Mailing list if selected" do
 
-      # try and create a new stanford user with this sunetid, which does not exist in database
-      new_user=User.create_new_sunet_user(@username)
-      expect(new_user.sunet).to eq(@username)
-      expect(new_user.username).to eq(@username)
-      expect(new_user.sunet_user?).to be_truthy
-      expect(new_user.email).to eq("#{@username}@stanford.edu")
+          expect(RevsMailer).to receive(:revs_institute_mailing_list_signup)
+          expect(RevsMailer).not_to receive(:mailing_list_signup)
 
-    end
+          @username='testing3'
+          @email="#{@username}@test.com"
+          # register a new user
+          register_new_user(@username,@password,@email)
+          check 'user_subscribe_to_revs_mailing_list'
+          click_button 'Sign up'
 
-     it "should create a username as the sunetID when a new Stanford user signs in via webauth, making it longer to have it be at least 5 characters" do
-    
-      @username="pet"
+          should_register_ok
 
-      expect(User.where(:username=>@username).size).to eq(0) # doesn't exist yet
+          # check the database
+          user=User.last
+          expect(user.role).to eq('user')
+          expect(user.username).to eq(@username)
+          expect(user.email).to eq(@email)
 
-      # try and create a new stanford user with this sunetid, which does not exist in database
-      new_user=User.create_new_sunet_user(@username)
-      expect(new_user.sunet).to eq(@username)
-      expect(new_user.username).to eq("#{@username}12")
-      expect(new_user.sunet_user?).to be_truthy
-      expect(new_user.email).to eq("#{@username}@stanford.edu")
+        end
+  
+       it "should create a username as the sunetID when a new Stanford user signs in via webauth" do
 
-    end
+        @username="somesunet"
 
-    it "should create a unique username based on the new Stanford users sunetID if a regular user already happens to be registered with that sunet ID as a username" do
-    
-      @username="somesunet"
-      @email="#{@username}@test.com" 
-      register_new_user(@username,@password,@email) 
-      sleep 6.seconds
-      click_button 'Sign up' 
+        expect(User.where(:username=>@username).size).to eq(0) # doesn't exist yet
 
-      should_register_ok
+        # try and create a new stanford user with this sunetid, which does not exist in database
+        new_user=User.create_new_sunet_user(@username)
+        expect(new_user.sunet).to eq(@username)
+        expect(new_user.username).to eq(@username)
+        expect(new_user.sunet_user?).to be_truthy
+        expect(new_user.email).to eq("#{@username}@stanford.edu")
 
-      # now try and create a new stanford user with this same sunetid as an already registered users and see if it uniquifies it
-      new_user=User.create_new_sunet_user(@username)
-      expect(new_user.sunet).to eq(@username)
-      expect(new_user.username).to eq("#{@username}_1")
-      expect(new_user.sunet_user?).to be_truthy
-      expect(new_user.email).to eq("#{@username}@stanford.edu")
-
-    end
-
-    it "should NOT register a new user via the web page if they have a Stanford email address or try a username with a Stanford email address" do
-
-        expect(RevsMailer).not_to receive(:mailing_list_signup)
-        expect(RevsMailer).not_to receive(:revs_institute_mailing_list_signup)
-
-        @username='testguy'
-        @email="#{@username}@stanford.edu" 
-
-        # try to register a new user with a stanford email address
-        register_new_user(@username,@password,@email) 
-        sleep 6.seconds
-
-        click_button 'Sign up'
-
-        expect(current_path).to eq(root_path)
-        expect(page).to have_content 'Stanford users should not create a new account.'
-
-        # check the database
-        user=User.last
-        expect(user.username).not_to eq(@username)
-        expect(user.email).not_to eq(@email)
-
-        # try to register a new stanford user with a stanford email address as the username
-        visit new_user_registration_path
-        register_new_user(@email,@password,"#{@username}@example.com") 
-        sleep 6.seconds
-
-        click_button 'Sign up'
-
-        expect(current_path).to eq(root_path)
-        expect(page).to have_content 'Stanford users should not create a new account.'
-
-        # check the database
-        user=User.last
-        expect(user.username).not_to eq(@email)
-        expect(user.email).not_to eq("#{@username}@example.com")
-        
       end
 
-      it "should NOT allow a user to reset their password if they have a Stanford email address" do
+       it "should create a username as the sunetID when a new Stanford user signs in via webauth, making it longer to have it be at least 5 characters" do
 
-          # try to reset the password of an existing stanford user
-          visit new_user_password_path
-          fill_in 'user_login', :with=> sunet_login
-          click_button 'submit'
+        @username="pet"
+
+        expect(User.where(:username=>@username).size).to eq(0) # doesn't exist yet
+
+        # try and create a new stanford user with this sunetid, which does not exist in database
+        new_user=User.create_new_sunet_user(@username)
+        expect(new_user.sunet).to eq(@username)
+        expect(new_user.username).to eq("#{@username}12")
+        expect(new_user.sunet_user?).to be_truthy
+        expect(new_user.email).to eq("#{@username}@stanford.edu")
+
+      end
+
+      it "should create a unique username based on the new Stanford users sunetID if a regular user already happens to be registered with that sunet ID as a username" do
+
+        @username="somesunet"
+        @email="#{@username}@test.com"
+        register_new_user(@username,@password,@email)
+        click_button 'Sign up'
+
+        should_register_ok
+
+        # now try and create a new stanford user with this same sunetid as an already registered users and see if it uniquifies it
+        new_user=User.create_new_sunet_user(@username)
+        expect(new_user.sunet).to eq(@username)
+        expect(new_user.username).to eq("#{@username}_1")
+        expect(new_user.sunet_user?).to be_truthy
+        expect(new_user.email).to eq("#{@username}@stanford.edu")
+
+      end
+
+      it "should NOT register a new user via the web page if they have a Stanford email address or try a username with a Stanford email address" do
+
+          expect(RevsMailer).not_to receive(:mailing_list_signup)
+          expect(RevsMailer).not_to receive(:revs_institute_mailing_list_signup)
+
+          @username='testguy'
+          @email="#{@username}@stanford.edu"
+
+          # try to register a new user with a stanford email address
+          register_new_user(@username,@password,@email)
+          sleep 4.seconds
+
+          click_button 'Sign up'
 
           expect(current_path).to eq(root_path)
-          expect(page).to have_content 'Stanford users need to login via webauth with their SunetID to access their account. You cannot reset your SunetID password here.'
+          expect(page).to have_content 'Stanford users should not create a new account.'
 
-      end      
-  
+          # check the database
+          user=User.last
+          expect(user.username).not_to eq(@username)
+          expect(user.email).not_to eq(@email)
+
+          # try to register a new stanford user with a stanford email address as the username
+          visit new_user_registration_path
+          register_new_user(@email,@password,"#{@username}@example.com")
+
+          click_button 'Sign up'
+
+          expect(current_path).to eq(root_path)
+          expect(page).to have_content 'Stanford users should not create a new account.'
+
+          # check the database
+          user=User.last
+          expect(user.username).not_to eq(@email)
+          expect(user.email).not_to eq("#{@username}@example.com")
+
+        end
+
+        it "should NOT allow a user to reset their password if they have a Stanford email address" do
+
+            # try to reset the password of an existing stanford user
+            visit new_user_password_path
+            fill_in 'user_login', :with=> sunet_login
+            click_button 'submit'
+
+            expect(current_path).to eq(root_path)
+            expect(page).to have_content 'Stanford users need to login via webauth with their SunetID to access their account. You cannot reset your SunetID password here.'
+
+        end
+
+    end
+
+    context 'spam registration' do
+
+      before :each do
+        @password='password'
+        Revs::Application.config.spam_reg_checks = true # enable spam checks for these tests
+      end
+
       it "should detect a spammer as someone who submits the form too quickly" do
 
         user_count = User.count
         @username='testing2'
         @email="#{@username}@test.com" 
         # register a new user
-        register_new_user(@username,@password,@email)    
+        register_new_user(@username,@password,@email)
 
         click_button 'Sign up'
 
@@ -207,13 +214,12 @@ describe("User Registration",:type=>:request,:integration=>true) do
         @username='testing2'
         @email="#{@username}@test.com" 
         # register a new user
-        register_new_user(@username,@password,@email)  
+        register_new_user(@username,@password,@email)
         within('#main-container') do    
           fill_in 'email_confirm', :with=>'hidden field'
         end
         
-        sleep 6.seconds
-
+        sleep 4.seconds
         click_button 'Sign up'
         
         expect(page).to have_content(I18n.t("revs.about.contact_message_spambot"))
@@ -221,5 +227,52 @@ describe("User Registration",:type=>:request,:integration=>true) do
         expect(User.count).to eq(user_count) # no new users
 
       end
-      
+
+      it "should not register a new user if they do not answer the reg question correctly or at all" do
+
+        user_count = User.count
+        @username='testing'
+        @email="#{@username}@test.com"
+        # try to register a new user but skip the registration question
+        visit new_user_registration_path
+        fill_in 'register-email', :with=> @email
+        fill_in 'register-username', :with=> @username
+        fill_in 'user_password', :with=> @password
+        fill_in 'user_password_confirmation', :with=> @password
+        sleep 4.seconds
+        click_button 'Sign up'
+        expect(page).to have_content 'Registration answer is not correct.'
+        expect(User.count).to eq(user_count) # no new users
+
+        # try to register a new user and answer the registration question incorrectly
+        visit new_user_registration_path
+        fill_in 'register-email', :with=> @email
+        fill_in 'register-username', :with=> @username
+        fill_in 'user_password', :with=> @password
+        fill_in 'user_password_confirmation', :with=> @password
+        fill_in 'user_registration_answer', :with=> 'totally bogus'
+        sleep 4.seconds
+        click_button 'Sign up'
+        expect(page).to have_content 'Registration answer is not correct.'
+        expect(User.count).to eq(user_count) # no new users
+
+      end
+
+      it "should register a new user if they answer the reg question correctly" do
+
+        @username='testing'
+        @email="#{@username}@test.com"
+        visit new_user_registration_path
+        fill_in 'register-email', :with=> @email
+        fill_in 'register-username', :with=> @username
+        fill_in 'user_password', :with=> @password
+        fill_in 'user_password_confirmation', :with=> @password
+        question_number = page.all("input#user_registration_question_number", :visible => false).first.value.to_i
+        fill_in 'user_registration_answer', :with=> Revs::Application.config.reg_questions[question_number][:answer]
+        sleep 4.seconds
+        click_button 'Sign up'
+        should_register_ok
+
+      end
+    end
 end

--- a/spec/features/user_reg_spec.rb
+++ b/spec/features/user_reg_spec.rb
@@ -208,7 +208,7 @@ describe("User Registration",:type=>:request,:integration=>true) do
 
         click_button 'Sign up'
 
-        expect(page).to have_content(I18n.t("revs.about.contact_message_spambot"))
+        expect(page).to have_content(I18n.t("revs.user.spam_registration"))
         expect(current_path).to eq(root_path)
         expect(User.count).to eq(user_count) # no new users
         
@@ -228,12 +228,28 @@ describe("User Registration",:type=>:request,:integration=>true) do
         sleep 4.seconds
         click_button 'Sign up'
         
-        expect(page).to have_content(I18n.t("revs.about.contact_message_spambot"))
+        expect(page).to have_content(I18n.t("revs.user.spam_registration"))
         expect(current_path).to eq(root_path)
         expect(User.count).to eq(user_count) # no new users
 
       end
 
+      it "should detect a spammer as someone who fits a specific username pattern" do
+
+        user_count = User.count
+        @username='m9tlbdv809'
+        @email="#{@username}@test.com" 
+        # register a new user
+        register_new_user(@username,@password,@email)        
+        sleep 4.seconds
+        click_button 'Sign up'
+        
+        expect(page).to have_content(I18n.t("revs.user.spam_registration"))
+        expect(current_path).to eq(root_path)
+        expect(User.count).to eq(user_count) # no new users
+
+      end
+      
       it "should not register a new user if they do not answer the reg question correctly or at all" do
 
         user_count = User.count

--- a/spec/features/user_reg_spec.rb
+++ b/spec/features/user_reg_spec.rb
@@ -191,6 +191,10 @@ describe("User Registration",:type=>:request,:integration=>true) do
       before :each do
         @password='password'
         Revs::Application.config.spam_reg_checks = true # enable spam checks for these tests
+        Revs::Application.config.reg_questions = [
+          {:question=>'What is the name of the car company that manufacturers the Mustang?',:answer=>'Ford'},
+          {:question=>'What is the first name of the founder of Ferrari?',:answer=>'Enzo'}
+        ]
         Revs::Application.config.require_manual_account_activation = false # disable manual activation for these tests
       end
 
@@ -271,6 +275,22 @@ describe("User Registration",:type=>:request,:integration=>true) do
         fill_in 'user_password_confirmation', :with=> @password
         question_number = page.all("input#user_registration_question_number", :visible => false).first.value.to_i
         fill_in 'user_registration_answer', :with=> Revs::Application.config.reg_questions[question_number][:answer]
+        sleep 4.seconds
+        click_button 'Sign up'
+        should_register_ok
+
+      end
+      
+      it "should register a new user if there are no reg questions configured" do
+
+        @username='testing'
+        @email="#{@username}@test.com"
+        Revs::Application.config.reg_questions = []
+        visit new_user_registration_path
+        fill_in 'register-email', :with=> @email
+        fill_in 'register-username', :with=> @username
+        fill_in 'user_password', :with=> @password
+        fill_in 'user_password_confirmation', :with=> @password
         sleep 4.seconds
         click_button 'Sign up'
         should_register_ok

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,7 @@ end
 def should_register_ok
    expect(current_path).to eq(root_path)
    expect(page).to have_content I18n.t('devise.registrations.signed_up_but_unconfirmed')
+   expect(User.last.active).to be_truthy
 end
 
 def login_as(login, password = nil)


### PR DESCRIPTION
- Provide an option that requires users to answer a registration question in order to complete registration
- Provide an option to require users to have their accounts manually activated by an administrator
- Receive a daily email with new account registrations that are inactive
- Block user registrations with known malicious username patterns (based on regex)