### PR TITLE
provide an option to close new user registrations

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -4,15 +4,16 @@ class RegistrationsController < Devise::RegistrationsController
   prepend_before_filter :authenticate_scope!, :only => [:edit, :update, :destroy, :edit_account, :update_account]
   before_filter :no_sunet_users, :only=>[ :edit_account, :update_account]
   before_filter :ajax_only, :only=>[:check_username,:check_email]
-  
+  before_filter :registration_closed, :only=>[:new,:create], :if=>lambda{Revs::Application.config.disable_new_registrations == true}
+
   # sign up form
   def new
     return if redirect_home_if_signed_in
     store_referred_page
     super
   end
-    
-  # sign up form submit method  
+
+  # sign up form submit method
   def create
     @spammer=params[:email_confirm] # if this hidden field is filled in, its a spam bot
     @loadtime=params[:loadtime] # this is the time the page was rendered, if it is submitted too fast, its a spammer
@@ -28,31 +29,31 @@ class RegistrationsController < Devise::RegistrationsController
 
     else
       super
-      
+
     end
 
   end
 
   # override devise update profile page so that user is not required to enter the current password
   def update
-    
+
     @user = User.find(current_user.id)
 
     params[:user].delete(:password)  # these aren't on the form, but let's remove them anyway to prevent hacking attempt
     params[:user].delete(:password_confirmation)  # these aren't on the form, but let's remove them anyway to prevent hacking attempt
     params[:user].delete(:current_password)  # these aren't on the form, but let's remove them anyway to prevent hacking attempt
     params[:user].delete(:email)
-    
+
     # check to be sure they aren't changing their username to something that includes @stanford.edu
-    
+
     if params[:user][:username].include?('@stanford.edu') && @user.sunet_user? && params[:user][:username] != "#{@user.sunet}@stanford.edu"
         @user.errors.add(:base,t('revs.authentication.stanford_email_warning1'))
         successfully_updated = false
     elsif params[:user][:username].include?('@stanford.edu') && !@user.sunet_user?
         @user.errors.add(:base,t('revs.authentication.stanford_email_warning2'))
-        successfully_updated = false      
+        successfully_updated = false
     else
-      successfully_updated = @user.update_without_password(user_params)      
+      successfully_updated = @user.update_without_password(user_params)
     end
 
     if successfully_updated
@@ -64,8 +65,8 @@ class RegistrationsController < Devise::RegistrationsController
       render "edit"
     end
 
-  end    
-  
+  end
+
   # logged in user edit email/password form
   def edit_account
     @user = User.find(current_user.id)
@@ -88,16 +89,16 @@ class RegistrationsController < Devise::RegistrationsController
     end
 
   end
-  
+
   # ajax call to check usernames
   def check_username
-    @user=User.where('username=?',params[:username])    
+    @user=User.where('username=?',params[:username])
     @user=[] if user_signed_in? && @user && @user.first==current_user  # this means they are editing their username and its themselves, that is ok
   end
-  
+
   # ajax call to check emails
   def check_email
-    @user=User.where('email=?',params[:email])    
+    @user=User.where('email=?',params[:email])
     @user=[] if user_signed_in? && @user && @user.first==current_user  # this means they are editing their email address and its themselves, that is ok
   end
 
@@ -107,10 +108,15 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   private
+  def registration_closed
+    flash[:alert]=t('revs.user.registration_closed')
+    redirect_to root_path
+  end
+
   def user_params
     params.require(:user).permit(:username, :email, :sunet, :password, :password_confirmation, :current_password, :remember_me,
                   :role, :bio, :first_name, :last_name, :public, :url, :twitter, :login,
-                  :subscribe_to_mailing_list, :subscribe_to_revs_mailing_list, :active, 
+                  :subscribe_to_mailing_list, :subscribe_to_revs_mailing_list, :active,
                   :avatar, :avatar_cache, :remove_avatar, :login_count, :favorites_public,
                   :registration_answer, :registration_question_number)
   end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -54,7 +54,7 @@
     <div class="form-group">
       <div class="col-sm-offset-4 col-sm-6 col-md-offset-3">
         <%= submit_tag "#{t('revs.authentication.sign_in')}", :id=>'submit', :class => 'btn btn-default signin' %>
-        <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+        <%- if devise_mapping.registerable? && controller_name != 'registrations' && Revs::Application.config.disable_new_registrations == false%>
           <%= link_to t('revs.authentication.new_user'), new_registration_path(resource_name) %>
         <% end -%>
       </div>

--- a/app/views/devise/shared/_links.erb
+++ b/app/views/devise/shared/_links.erb
@@ -2,7 +2,7 @@
   <%= link_to t('revs.user.sign_in'), new_session_path(resource_name) %><br />
 <% end -%>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+<%- if devise_mapping.registerable? && controller_name != 'registrations' && Revs::Application.config.disable_new_registrations == false%>
   <%= link_to t('revs.user.sign_up'), new_registration_path(resource_name) %><br />
 <% end -%>
 

--- a/app/views/shared/_user_navigation.html.erb
+++ b/app/views/shared/_user_navigation.html.erb
@@ -35,6 +35,8 @@
 <% else %>
   <%=link_to t('revs.user.sign_in'),new_user_session_path%>
   <span class="nav-element-divider">|</span>
-  <%=link_to t('revs.user.sign_up'),new_user_registration_path%>
-  <span class="nav-element-divider">|</span>
+  <% unless Revs::Application.config.disable_new_registrations %>
+    <%=link_to t('revs.user.sign_up'),new_user_registration_path %>
+    <span class="nav-element-divider">|</span>
+  <% end %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -130,6 +130,7 @@ module Revs
     #   {:question=>'What is the name of the car company that manufacturers the Mustang?',:answer=>'Ford'},
     #   {:question=>'What is the first name of the founder of Ferrari?',:answer=>'Enzo'}
     # ]
+    config.disable_new_registrations = true # set to true to disable new users from registering (useful in conjunction with disable_editing or if there is a sustained period of bogus registrations)
     config.require_manual_account_activation = true # set to true to require an admin to manually activate any new account registrations
     config.new_registration_notification = 'petucket@stanford.edu' # email address to receive daily notifications of new registrations
     config.spam_reg_checks = true # set to false to skip spam registration checks (useful in testing)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -566,6 +566,7 @@ en:
       label_metadata_sources: "Metadata Sources"
       label_more_metadata: "Has more metadata"
     user:
+      registration_closed: 'New user registration is temporarily closed.'
       spam_registration: 'Your IP address has been reported as a suspected malicious registration and your account has been deleted.'
       stanford_warning_html: '<strong>Important:</strong> Stanford users should not create a new account or enter their SUNET ID or passwords on this website.  %{webauth_link}'
       stanford_email_sunet_warning_html: ' <strong>Note</strong>.  You have not changed your default username, which is your Stanford SUNET ID.'

--- a/spec/features/user_reg_spec.rb
+++ b/spec/features/user_reg_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
 describe("User Registration",:type=>:request,:integration=>true) do
-  
+
   context 'regular registration' do
-  
+
     before :each do
       @password='password'
       Revs::Application.config.spam_reg_checks = false # disable spam checks for these tests
+      Revs::Application.config.disable_new_registrations = false # be sure registration is enabled for these tests
       Revs::Application.config.require_manual_account_activation = false # disable manual activation for these tests
       RevsMailer.stub_chain(:mailing_list_signup,:deliver).and_return('a mailer')
       RevsMailer.stub_chain(:revs_institute_mailing_list_signup,:deliver).and_return('a mailer')
@@ -48,7 +49,7 @@ describe("User Registration",:type=>:request,:integration=>true) do
         expect(RevsMailer).not_to receive(:revs_institute_mailing_list_signup)
 
         @username='testing2'
-        @email="#{@username}@test.com" 
+        @email="#{@username}@test.com"
         # register a new user
         register_new_user(@username,@password,@email)
         check 'user_subscribe_to_mailing_list'
@@ -85,7 +86,7 @@ describe("User Registration",:type=>:request,:integration=>true) do
           expect(user.email).to eq(@email)
 
         end
-  
+
        it "should create a username as the sunetID when a new Stanford user signs in via webauth" do
 
         @username="somesunet"
@@ -191,6 +192,7 @@ describe("User Registration",:type=>:request,:integration=>true) do
       before :each do
         @password='password'
         Revs::Application.config.spam_reg_checks = true # enable spam checks for these tests
+        Revs::Application.config.disable_new_registrations = false # be sure registration is enabled for these tests
         Revs::Application.config.reg_questions = [
           {:question=>'What is the name of the car company that manufacturers the Mustang?',:answer=>'Ford'},
           {:question=>'What is the first name of the founder of Ferrari?',:answer=>'Enzo'}
@@ -202,7 +204,7 @@ describe("User Registration",:type=>:request,:integration=>true) do
 
         user_count = User.count
         @username='testing2'
-        @email="#{@username}@test.com" 
+        @email="#{@username}@test.com"
         # register a new user
         register_new_user(@username,@password,@email)
 
@@ -211,23 +213,23 @@ describe("User Registration",:type=>:request,:integration=>true) do
         expect(page).to have_content(I18n.t("revs.user.spam_registration"))
         expect(current_path).to eq(root_path)
         expect(User.count).to eq(user_count) # no new users
-        
+
       end
 
       it "should detect a spammer as someone who fills in the hidden form field" do
 
         user_count = User.count
         @username='testing2'
-        @email="#{@username}@test.com" 
+        @email="#{@username}@test.com"
         # register a new user
         register_new_user(@username,@password,@email)
-        within('#main-container') do    
+        within('#main-container') do
           fill_in 'email_confirm', :with=>'hidden field'
         end
-        
+
         sleep 4.seconds
         click_button 'Sign up'
-        
+
         expect(page).to have_content(I18n.t("revs.user.spam_registration"))
         expect(current_path).to eq(root_path)
         expect(User.count).to eq(user_count) # no new users
@@ -238,18 +240,18 @@ describe("User Registration",:type=>:request,:integration=>true) do
 
         user_count = User.count
         @username='m9tlbdv809'
-        @email="#{@username}@test.com" 
+        @email="#{@username}@test.com"
         # register a new user
-        register_new_user(@username,@password,@email)        
+        register_new_user(@username,@password,@email)
         sleep 4.seconds
         click_button 'Sign up'
-        
+
         expect(page).to have_content(I18n.t("revs.user.spam_registration"))
         expect(current_path).to eq(root_path)
         expect(User.count).to eq(user_count) # no new users
 
       end
-      
+
       it "should not register a new user if they do not answer the reg question correctly or at all" do
 
         user_count = User.count
@@ -296,7 +298,7 @@ describe("User Registration",:type=>:request,:integration=>true) do
         should_register_ok
 
       end
-      
+
       it "should register a new user if there are no reg questions configured" do
 
         @username='testing'
@@ -313,15 +315,16 @@ describe("User Registration",:type=>:request,:integration=>true) do
 
       end
     end
-    
+
     context 'manual activation for registration' do
 
       before :each do
         @password='password'
         Revs::Application.config.spam_reg_checks = false # disable spam checks for these tests
+        Revs::Application.config.disable_new_registrations = false # be sure registration is enabled for these tests
         Revs::Application.config.require_manual_account_activation = true # enable manual activation for these tests
       end
-      
+
       it "should register a new user but inactivate their account" do
         @username='testing'
         @email="#{@username}@test.com"
@@ -335,6 +338,28 @@ describe("User Registration",:type=>:request,:integration=>true) do
         expect(page).to have_content I18n.t('devise.registrations.user.signed_up_but_account_has_been_deactivated')
         expect(User.last.active).to be_falsey
       end
-      
+
+    end
+
+    context 'registration closed' do
+
+      before :each do
+        @password='password'
+        Revs::Application.config.spam_reg_checks = false # disable spam checks for these tests
+        Revs::Application.config.disable_new_registrations = true # testing registration closed
+        Revs::Application.config.require_manual_account_activation = true # enable manual activation for these tests
+      end
+
+      it "should not allow new registrations" do
+        visit new_user_registration_path
+        expect(current_path).to eq(root_path)
+        expect(page).to have_content I18n.t('revs.user.registration_closed')
+      end
+
+      it "should not allow new registrations" do
+        visit root_path
+        expect(page).to_not have_content I18n.t('revs.user.sign_up')
+      end
+
     end
 end


### PR DESCRIPTION
useful when editing is disabled (user accounts aren't useful then) and/or if there are a large number of bogus registrations happening (try to get them to go away)