### PR TITLE
Replace masthead image with solid color background

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -1,12 +1,3 @@
-@mixin masthead-background-containers() {
-  position: absolute;
-  left: 0;
-  right: 0;
-  display: block;
-  width: auto;
-  height: inherit;
-}
-
 #brandbar {
   font-family: 'Source Sans Pro',Arial,sans-serif;
   font-size: 14px;
@@ -122,14 +113,14 @@
   }
 }
 
-$masthead-height: 186px;
-$masthead-image-blur: 2px;
+$masthead-height: 165px;
 $menu-link-background-color-active: rgba(255, 255, 255, 0.25);
 $menu-link-background-color-hover: rgba(255, 255, 255, 0.15);
 
 #revs-masthead {
+  background-color: #5f574f;
   height: $masthead-height;
-  margin-bottom: -46px;
+  margin-bottom: -45px;
   padding: 0;
   position: static;
 
@@ -171,37 +162,6 @@ $menu-link-background-color-hover: rgba(255, 255, 255, 0.15);
       font-style: normal;
       text-shadow: none;
     }
-  }
-
-  // This is to add a background image to the masthead, in a way that
-  // enables the site title and subtitle text to be visible above it.
-  .background-container {
-    @include masthead-background-containers();
-    background-repeat: no-repeat;
-    background-size: cover;
-    // Add small amount of blur to help text stand out
-    -webkit-filter: blur($masthead-image-blur);
-    filter: blur($masthead-image-blur);
-    // Shift image slightly to hide blurred edge of image
-    margin-left: -$masthead-image-blur;
-    margin-top: -$masthead-image-blur - 1;
-    overflow: hidden;
-    // Add right border to image to hide lighter blurred edge
-    border-right: 1px solid $gray-base;
-  }
-
-  // Include gradient to improve text legibility,
-  // especially on light background images.
-  .background-container-gradient {
-    @include masthead-background-containers();
-    background:
-     linear-gradient(
-       rgba(0, 0, 0, 0.0),
-       rgba(0, 0, 0, 0.2),
-       rgba(0, 0, 0, 0.3)
-     );
-     // Compensate for negative top margin of background-container
-     height: $masthead-height - $masthead-image-blur;
   }
 }
 

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -19,8 +19,6 @@
 
 <% cache("navbar", :expires_in=>6.hours, :skip_digest=>true) do %>
   <div id="revs-masthead">
-    <span class='background-container' style="background-image: url('<%= image_path('masthead-image-1800.jpg') %>')"></span>
-    <span class='background-container-gradient'></span>
     <div class="container">
       <div class="site-title h1">
         <%= link_to application_name, root_path %>


### PR DESCRIPTION
Not the most exciting color but it's a good color for accessibility and not clashing with existing color palette. 

<img width="528" alt="automobility_archive__search" src="https://user-images.githubusercontent.com/101482/33581143-dd8dc532-d90c-11e7-908f-934d9f079260.png">
