### PR TITLE
Send an email to users when accounts are activated

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -55,6 +55,7 @@ class Admin::UsersController < AdminController
       params[:user].delete(:password_confirmation)
     end
     @user=User.find(params[:id])
+    @user.update_account_status(params[:user][:active]) if params[:user][:active] != @user.active
     if @user.update_attributes(user_params)
      @user.update_lock_status(params[:lock])
      flash[:success]=t('revs.messages.saved')
@@ -69,11 +70,7 @@ class Admin::UsersController < AdminController
     @status=params[:status]
     @selected_users=params[:selected_users]
     if @selected_users
-      @selected_users.each do |user_id|
-          user=User.find(user_id)
-          user.active=@status
-          user.save
-       end
+      @selected_users.each { |user_id| User.find(user_id).update_account_status(@status) }
       flash[:success]=t('revs.admin.user_status_updated',:num=>@selected_users.size,:status=>@status)
     else
       flash[:error]=t('revs.admin.no_users_updated')

--- a/app/mailers/revs_mailer.rb
+++ b/app/mailers/revs_mailer.rb
@@ -35,6 +35,11 @@ class RevsMailer < ActionMailer::Base
     mail(:to=>flag.user.email,:subject=>I18n.t('revs.flags.resolved_message')) if flag.user && flag.user.email && valid_email?(flag.user.email)
   end
 
+  def account_activated(user)
+    @user=user
+    mail(:to=>user.email,:subject=>I18n.t('revs.authentication.account_activated')) if user && user.active && valid_email?(user.email)
+  end
+
   def mailing_list_signup(opts={})
     mail(:to=>"revs-program-join@lists.stanford.edu",:from=>opts[:from],:subject=>"Request to be added to the Revs Program Mailing List",:body=>"Subscribe")
   end

--- a/app/views/revs_mailer/account_activated.html.erb
+++ b/app/views/revs_mailer/account_activated.html.erb
@@ -1,0 +1,2 @@
+<p>Your account has been activated on Automobility Archive.  You can now <%=link_to t('revs.user.sign_in'),new_user_session_path%>.</p>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,6 +254,7 @@ en:
          Lock the account immediately by checking the box.
          The user can unlock by verifying their email address or you can unlock by unchecking this box.
       lock_account: "Lock account"
+      account_activated: 'Your account has been activated.'
     admin:
       administer_users: "Manage Users"
       find_users: "Find users"


### PR DESCRIPTION
Users whose accounts are deactivated by default after registering (or whose accounts are later made inactive) do not currently get a notification to tell them their accounts have been activated by an administrator.  This PR sends an email to a user each time their account is changed from "inactive" to "active".  There are no UI changes, just a really simple short email to users when their account status changes.