### PR TITLE
Set anonymizeIP true for Google Analytics

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,6 +28,7 @@ module ApplicationHelper
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', '#{GOOGLE_ANALYTICS_CODE}', 'stanford.edu');
+        ga('set', 'anonymizeIp', true);
         ga('send', 'pageview');
 
       </script>


### PR DESCRIPTION
A friendly PR to anonymizeIP for automobility.stanford.edu as we do this throughout our public portfolio